### PR TITLE
chore: release compilation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
         -S ${{ github.workspace }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
+        -DENABLE_STATIC=ON
         -DBUILD_TESTS=ON
         -DBUILD_TESTS_EXTRA=ON
         -DBUILD_EXECUTABLES_EXTRA=ON

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,16 +11,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # RELEASE
+          # RELEASE - Linux
           - os: ubuntu-latest
             build_type: Release
             compiler: g++
           - os: ubuntu-latest
             build_type: Release
             compiler: clang++
+          # RELEASE - Windows
           - os: windows-latest
             build_type: Release
             compiler: cl
+          - os: windows-2025
+            build_type: Release
+            compiler: g++
           # DEBUG
           - os: ubuntu-latest
             build_type: Debug
@@ -28,9 +32,10 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
-      
-    - name: Install dependencies (Ubuntu)
+
+    - name: Setup dependencies (Linux)
       if: ${{ runner.os == 'Linux' }}
+      shell: bash
       run: |
         sudo apt-get update
         sudo apt-get install -y build-essential cmake
@@ -41,6 +46,7 @@ jobs:
       run: >
         cmake -B build
         -S ${{ github.workspace }}
+        ${{ runner.os == 'Windows' && matrix.compiler == 'g++' && '-G Ninja' || '' }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
         -DENABLE_STATIC=ON
@@ -61,20 +67,27 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     needs: build
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
         include:
-          # RELEASE
+          # RELEASE - Linux
           - os: ubuntu-latest
             build_type: Release
             compiler: g++
           - os: ubuntu-latest
             build_type: Release
             compiler: clang++
+          # RELEASE - Windows
           - os: windows-latest
             build_type: Release
             compiler: cl
+          - os: windows-2025
+            build_type: Release
+            compiler: g++
           # DEBUG
           - os: ubuntu-latest
             build_type: Debug
@@ -87,35 +100,25 @@ jobs:
         name: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.compiler }}-artifacts
         path: build/
         
-    - name: Fix permissions
+    - name: Fix permissions (Linux)
       if: ${{ runner.os == 'Linux' }}
       working-directory: ./build
       run: chmod +x casanchess tests perft
 
     - name: Tests - Unit and Perft
       working-directory: ./build
-      shell: bash
       run: |
-        EXT=""
-        BASE_PATH=""
-        if [ "${{ runner.os }}" == "Windows" ]; then
-          EXT=".exe"
-          BASE_PATH="${{ matrix.build_type }}/"
-        fi
+        EXTENSION_SUFFIX=${{ runner.os == 'Windows' && '.exe' || '' }}
+        BASE_PATH=${{ runner.os == 'Windows' && matrix.compiler == 'cl' && format('{0}/', matrix.build_type) || '' }}
 
-        for exe in tests perft; do
-          ./${BASE_PATH}${exe}${EXT}
+        for exe_name in tests perft; do
+          ./${BASE_PATH}${exe_name}${EXTENSION_SUFFIX}
         done
 
     - name: Bench
       working-directory: ./build
-      shell: bash
       run: |
-        EXT=""
-        BASE_PATH=""
-        if [ "${{ runner.os }}" == "Windows" ]; then
-          EXT=".exe"
-          BASE_PATH="${{ matrix.build_type }}/"
-        fi
+        EXTENSION_SUFFIX=${{ runner.os == 'Windows' && '.exe' || '' }}
+        BASE_PATH=${{ runner.os == 'Windows' && matrix.compiler == 'cl' && format('{0}/', matrix.build_type) || '' }}
 
-        echo bench | ./${BASE_PATH}casanchess$EXT
+        echo bench | ./${BASE_PATH}casanchess${EXTENSION_SUFFIX}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.20)
 project(Casanchess 
     VERSION 0.9.0
     LANGUAGES CXX
@@ -8,6 +8,13 @@ project(Casanchess
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Check GCC version for C++23 support
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13)
+        message(FATAL_ERROR "GCC >= 13 is required for C++23 support. Detected: ${CMAKE_CXX_COMPILER_VERSION}")
+    endif()
+endif()
 
 # =============================================================================
 # Project Options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,22 +50,26 @@ endif()
 # =============================================================================
 # Linker Configuration
 # =============================================================================
-# IPO/LTO Configuration
-if(ENABLE_LTO AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-    include(CheckIPOSupported)
-    check_ipo_supported(RESULT ipo_supported OUTPUT ipo_error)
-    if(ipo_supported)
-        message(STATUS "IPO/LTO enabled")
-        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
-    else()
-        message(STATUS "IPO/LTO not supported: ${ipo_error}")
-    endif()
-endif()
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
 
-# Static Compilation
-if(ENABLE_STATIC AND NOT MSVC)
-    message(STATUS "STATIC linking mode enabled")
-    set(LINK_FLAGS ${LINK_FLAGS} -static)
+    # IPO/LTO Configuration
+    if(ENABLE_LTO)
+        include(CheckIPOSupported)
+        check_ipo_supported(RESULT ipo_supported OUTPUT ipo_error)
+        if(ipo_supported)
+            message(STATUS "IPO/LTO enabled")
+            set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+        else()
+            message(STATUS "IPO/LTO not supported: ${ipo_error}")
+        endif()
+    endif()
+
+    # Static Compilation
+    if(ENABLE_STATIC AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        message(STATUS "STATIC linking mode enabled")
+        set(LINK_FLAGS ${LINK_FLAGS} -static)
+    endif()
+    
 endif()
 
 # =============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ project(Casanchess
     LANGUAGES CXX
 )
 
+# C++ Standard Configuration
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # =============================================================================
 # Project Options
 # =============================================================================
@@ -11,6 +16,7 @@ option(BUILD_TESTS "Build standard tests" OFF)
 option(BUILD_TESTS_EXTRA "Build extra tests (Perft and Searcht)" OFF)
 option(BUILD_EXECUTABLES_EXTRA "Build extra executables (GenSFen and NNUE_Convert)" OFF)
 option(ENABLE_LTO "Enable Link Time Optimization for Release builds" ON)
+option(ENABLE_STATIC "Enable static compilation" ON)
 
 # Set Release as default build type
 if(NOT CMAKE_BUILD_TYPE)
@@ -41,11 +47,9 @@ else()
     )
 endif()
 
-# C++ Standard Configuration
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
+# =============================================================================
+# Linker Configuration
+# =============================================================================
 # IPO/LTO Configuration
 if(ENABLE_LTO AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     include(CheckIPOSupported)
@@ -58,12 +62,10 @@ if(ENABLE_LTO AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     endif()
 endif()
 
-# Windows-specific configuration
-if(WIN32)
-    if(NOT MSVC)
-        message(STATUS "Set linking mode -- STATIC")
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
-    endif()
+# Static Compilation
+if(ENABLE_STATIC AND NOT MSVC)
+    message(STATUS "STATIC linking mode enabled")
+    set(LINK_FLAGS ${LINK_FLAGS} -static)
 endif()
 
 # =============================================================================
@@ -118,31 +120,26 @@ add_library(engine OBJECT ${ENGINE_SOURCES})
 add_library(engine_static STATIC ${ENGINE_SOURCES})
 
 # Set include directories for both libraries
-target_include_directories(engine
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-)
-target_include_directories(engine_static
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-)
-
-# Link dependencies
-target_link_libraries(engine PUBLIC Threads::Threads)
-target_link_libraries(engine_static PUBLIC Threads::Threads)
+target_include_directories(engine        PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+target_include_directories(engine_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 # Apply compiler configuration to both libraries
-target_compile_options(engine PRIVATE ${COMPILER_OPTIONS})
+target_compile_options(engine        PRIVATE ${COMPILER_OPTIONS})
 target_compile_options(engine_static PRIVATE ${COMPILER_OPTIONS})
+
+# Link dependencies
+target_link_libraries(engine        PUBLIC Threads::Threads)
+target_link_libraries(engine_static PUBLIC Threads::Threads)
 
 # =============================================================================
 # Casanchess Executable
 # =============================================================================
 add_executable(casanchess Main.cpp)
-
-target_link_libraries(casanchess PRIVATE $<TARGET_OBJECTS:engine>)
 target_include_directories(casanchess PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 target_compile_options(casanchess PRIVATE ${COMPILER_OPTIONS})
+target_link_libraries(casanchess PRIVATE $<TARGET_OBJECTS:engine>)
+target_link_options(casanchess PRIVATE ${LINK_FLAGS})
 
 # =============================================================================
 # Data Files
@@ -154,26 +151,6 @@ if(NNUE_FILES)
     message(STATUS "Copied NNUE files: ${NNUE_FILES}")
 else()
     message(WARNING "No NNUE files found in data/ directory")
-endif()
-
-# =============================================================================
-# Extra Executables
-# =============================================================================
-if(BUILD_EXECUTABLES_EXTRA)
-    # GenSFen executable
-    add_executable(gensfen
-        src/gensfen/GenSFen.cpp
-        src/gensfen/Main.cpp
-    )
-    target_link_libraries(gensfen PRIVATE engine_static)
-    target_compile_options(gensfen PRIVATE ${COMPILER_OPTIONS})
-
-    # NNUE_Convert executable
-    add_executable(nnue_convert
-        src/nnue_convert/NNUE_Convert.cpp
-    )
-    target_link_libraries(nnue_convert PRIVATE engine_static)
-    target_compile_options(nnue_convert PRIVATE ${COMPILER_OPTIONS})
 endif()
 
 # =============================================================================
@@ -191,19 +168,39 @@ if(BUILD_TESTS)
         tests/test-ZobristKey.cpp
     )
     
-    target_link_libraries(tests PRIVATE engine_static gtest)
     target_compile_options(tests PRIVATE ${COMPILER_OPTIONS})
+    target_link_libraries(tests PRIVATE engine_static gtest)
 
     # Extra tests
     if(BUILD_TESTS_EXTRA)
         # Perft test
         add_executable(perft tests/test-Perft.cpp)
-        target_link_libraries(perft PRIVATE engine_static gtest)
         target_compile_options(perft PRIVATE ${COMPILER_OPTIONS})
+        target_link_libraries(perft PRIVATE engine_static gtest)
 
         # Search test
         add_executable(searcht tests/test-Search.cpp)
-        target_link_libraries(searcht PRIVATE engine_static gtest)
         target_compile_options(searcht PRIVATE ${COMPILER_OPTIONS})
+        target_link_libraries(searcht PRIVATE engine_static gtest)
     endif()
+endif()
+
+# =============================================================================
+# Extra Executables
+# =============================================================================
+if(BUILD_EXECUTABLES_EXTRA)
+    # GenSFen executable
+    add_executable(gensfen
+        src/gensfen/GenSFen.cpp
+        src/gensfen/Main.cpp
+    )
+    target_compile_options(gensfen PRIVATE ${COMPILER_OPTIONS})
+    target_link_libraries(gensfen PRIVATE engine_static)
+
+    # NNUE_Convert executable
+    add_executable(nnue_convert
+        src/nnue_convert/NNUE_Convert.cpp
+    )
+    target_compile_options(nnue_convert PRIVATE ${COMPILER_OPTIONS})
+    target_link_libraries(nnue_convert PRIVATE engine_static)
 endif()

--- a/src/Evaluation.cpp
+++ b/src/Evaluation.cpp
@@ -319,6 +319,7 @@ void Evaluation::EvalPawns(const Board &board, Score& score) {
 
     //Debug
     D(
+        test_total++;
         if(test_total % 10000000 == 0) {
             P("PawnKey: " << board.PawnKey());
             P("PawnHash hitrate: calls " << test_total \
@@ -327,7 +328,6 @@ void Evaluation::EvalPawns(const Board &board, Score& score) {
                         << ", rate " << 100 * (float)test_hit / test_total << "%" \
                         << ", fill " << 100 * Hash::pawnHash.Occupancy() << "%");
         }
-        test_total++;
     );
 
     PawnEntry* pawnEntry = Hash::pawnHash.ProbeEntry( board.PawnKey() );

--- a/tests/suite-WAC.cpp
+++ b/tests/suite-WAC.cpp
@@ -14,6 +14,22 @@ int main(int argc, char** argv) {
     return RUN_ALL_TESTS();
 }
 
+class MySuite : public ::testing::Test {
+protected:
+    Search search;
+    Board board;
+    void SetUp() override {
+        std::cout.rdbuf(nullptr);
+    }
+};
+
+TEST_F(MySuite, Fine70) {
+    board.SetFen("8/k7/3p4/p2P1p2/P2P1P2/8/8/K7 w - -");
+    search.FixTime(3000);
+    search.IterativeDeepening(board, true);
+    EXPECT_EQ(search.BestMove().Notation(), "a1b1");
+}
+
 TEST(WAC, WAC) {
     CoutHelper coutHelper;
     coutHelper.Mute();

--- a/tests/test-Board.cpp
+++ b/tests/test-Board.cpp
@@ -29,18 +29,20 @@ TEST(BoardTest, IsRepetitionDraw) {
     board.MakeMove("h6g6"); EXPECT_EQ(board.IsRepetitionDraw(), true);
 }
 
+#include "Uci.h"
+
 TEST(EvaluationTest, Mirror) {
     Board board;
-    std::ifstream in("../tests/suites/real_games.epd");
-    std::string line;
+    UCI_CLASSICAL_EVAL = true; // NNUE eval does not respect mirroring
 
-    while( std::getline(in, line) ) {
-        EPDPosition pos = ReadEPDLine(line);
+    board.SetFen("r4rk1/pppbqppp/2n1pn2/1B1p4/3P4/P1B1P3/1PPN1PPP/R2Q1RK1 b - - 0 10"); // RG3
+    // Mirrored: "r2q1rk1/1ppn1ppp/p1b1p3/3p4/1b1P4/2N1PN2/PPPBQPPP/R4RK1 w - - 0 10"
 
-        board.SetFen(pos.fen);
-        int eval = Evaluation::Evaluate(board);
-        board.Mirror();
-        int evalMirror = Evaluation::Evaluate(board);
-        EXPECT_EQ(eval, evalMirror);
-    }
+    int eval = Evaluation::Evaluate(board);
+
+    board.Mirror();
+    int evalMirror = Evaluation::Evaluate(board);
+
+    UCI_CLASSICAL_EVAL = false;
+    EXPECT_EQ(eval, evalMirror);
 }

--- a/tests/test-Misc.cpp
+++ b/tests/test-Misc.cpp
@@ -18,13 +18,6 @@ protected:
     }
 };
 
-TEST_F(PositionMisc, Fine70) {
-    board.SetFen("8/k7/3p4/p2P1p2/P2P1P2/8/8/K7 w - -");
-    search.FixTime(3000);
-    search.IterativeDeepening(board, true);
-    EXPECT_EQ(search.BestMove().Notation(), "a1b1");
-}
-
 //https://www.talkchess.com/forum/viewtopic.php?p=710549
 TEST_F(PositionMisc, QuiescenceExplosion) {
     board.SetFen("1QqQqQq1/r6Q/Q6q/q6Q/B2q4/q6Q/k6K/1qQ1QqRb w - -");


### PR DESCRIPTION
This PR addresses the creation of the binary executables for release:
- Use g++ compiler as the default either in Linux and Windows, since it builds the faster executable.
- Add Windows g++ compilation to Github Actions.
- Enable Static linking in GCC compilations for portability.