### PR TITLE
feat: rfp: 100 -> 75

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -413,7 +413,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
 
     // --- Reverse Futility Pruning ---
     // Prune if static evaluation is too good (eval >> beta)
-    const int staticMargin = 100;
+    const int staticMargin = 75;
     if(depth <= 4 && !isPV && !inCheck) {
         int staticEval = eval - depth * staticMargin;
         if(staticEval >= beta) {


### PR DESCRIPTION
Tune the parameter for Reverse Futility Pruning.
New value: **75** (previous: 100).

Results in a more aggresive pruning.