### PR TITLE
refactor: bitboard iterator

### DIFF
--- a/include/BitboardUtils.h
+++ b/include/BitboardUtils.h
@@ -3,6 +3,8 @@
 
 #include "Constants.h"
 
+#include <bit>
+
 namespace BitboardUtils {
     //Gives the value of the bit in 'position'
     template <typename T>
@@ -38,7 +40,7 @@ namespace BitboardUtils {
     int ResetLsb(Bitboard &b);
 
     Bitboard IsolateLsb(Bitboard b);
-    void RemoveLsb(Bitboard &b);
+    inline void RemoveLsb(Bitboard &b) { b &= (b - 1); };
 
     Bitboard North(Bitboard bitboard, int times = 1);
     Bitboard South(Bitboard bitboard, int times = 1);
@@ -51,5 +53,32 @@ namespace BitboardUtils {
 }
 
 using namespace BitboardUtils;
+
+class BitboardIterator {
+public:
+    explicit BitboardIterator(Bitboard bitboard) noexcept : m_bitboard(bitboard) {}
+
+    class iterator {
+        Bitboard b;
+    public:
+        explicit iterator(Bitboard bitboard) noexcept : b(bitboard) {}
+
+        int operator*() const noexcept {
+            return BitscanForward(b);
+        }
+        iterator& operator++() noexcept {
+            RemoveLsb(b);
+            return *this;
+        }
+        bool operator!=(const iterator& other) const noexcept {
+            return b != other.b;
+        }
+    };
+
+    iterator begin() const noexcept { return iterator(m_bitboard); }
+    iterator end() const noexcept { return iterator(0); }
+private:
+    Bitboard m_bitboard;
+};
 
 #endif //BITBOARDUTILS_H

--- a/include/MoveGenerator.h
+++ b/include/MoveGenerator.h
@@ -20,7 +20,11 @@ public:
     static Move RandomMove(const MoveList& moves);
 
 private:
+    enum GENERATION_TYPE {LEGAL, EVASION, TACTICAL};
+
     void Init(const Board &board);
+
+    void Generate(Board &board, GENERATION_TYPE type);
 
     void GeneratePseudoMoves(Board &board);
 
@@ -37,8 +41,6 @@ private:
     Bitboard PinnedPieces(Board &board, COLOR color);
     Bitboard FillPinned(PIECE_TYPE slidingType, int square, int kingSquare);
 
-    MoveList m_moves;
-
     COLOR m_color;
     COLOR m_enemyColor;
     bool m_generateQuiet;
@@ -49,12 +51,14 @@ private:
 
     Bitboard m_kingDangerSquares;
 
-    Bitboard m_captureMask; //the piece giving check
-    Bitboard m_pushMask; //squares that block a check
+    Bitboard m_captureMask; // Squares where capture is allowed. In case of check, the piece giving check
+    Bitboard m_pushMask; // Squares where push is allowed. In case of check, squares that block a check
 
     Bitboard m_pinned;
     Bitboard m_pinnedCaptureMask[64];
     Bitboard m_pinnedPushMask[64];
+
+    MoveList m_moves;
 };
 
 #endif //MOVEGENERATOR_H

--- a/src/BitboardUtils.cpp
+++ b/src/BitboardUtils.cpp
@@ -13,9 +13,8 @@ x & (x-1): removes the LSB (LSB reset)
 
 // Returns the index of the first '1' bit (LSB)
 int BitboardUtils::BitscanForward(Bitboard b) {
-    if(b)
-        return std::countr_zero(b);
-    return -1;
+    if(b == 0) return -1;
+    return std::countr_zero(b);
 }
 
 //Gives the index of the last '1' bit (MSB)
@@ -40,10 +39,6 @@ int BitboardUtils::ResetLsb(Bitboard &b) {
 //Returns a bitboard with the LSB only
 Bitboard BitboardUtils::IsolateLsb(Bitboard b) {
 	return b & (~b + 1);
-}
-
-void BitboardUtils::RemoveLsb(Bitboard &b) {
-    b &= (b - 1);
 }
 
 //Moves all bits to a given direction a certain number of times.

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -97,8 +97,7 @@ void Board::Print(bool bits) const {
     for(COLOR color : {WHITE, BLACK}) {
         for(PIECE_TYPE piece = PAWN; piece <= KING; ++piece) {
             Bitboard thePieces = m_pieces[color][piece];
-            while(thePieces) {
-                int index = ResetLsb(thePieces);
+            for(int index : BitboardIterator(thePieces)) {
                 squareMap[index] = '\0';
                 squareMap[index] += (color == WHITE) ? "\033[1;97m" : "\033[1;31m"; //white or red
                 squareMap[index] += PIECE_NOTATION[color][piece];

--- a/src/Evaluation.cpp
+++ b/src/Evaluation.cpp
@@ -144,8 +144,7 @@ void Evaluation::Init() {
         KING_INNER_RING[square] = Attacks::AttacksKing(square);
         //Outer ring is the sum of the attacks from each square of the inner ring, minus the inner ring and the king square
         Bitboard bb = KING_INNER_RING[square];
-        while(bb) {
-            int innerSquare = ResetLsb(bb);
+        for(int innerSquare : BitboardIterator(bb)) {
             KING_OUTER_RING[square] |= Attacks::AttacksKing(innerSquare);
         }
         KING_OUTER_RING[square] ^= KING_INNER_RING[square] | SquareBB(square);
@@ -369,9 +368,7 @@ TaperedScore Evaluation::EvalPawnsCalculation(const Board &board, COLOR color) {
     score.eg += doubledPawns * parameters.DOUBLED_PAWN[EG] / 2;
 
     Bitboard bb = thePawns;
-    while(bb) {
-        int square = ResetLsb(bb);
-
+    for(int square : BitboardIterator(bb)) {
         //Psqt
         int index = SQUARE_CONVERSION[color][square];
         score.mg += parameters.PSQT[PAWN][index];
@@ -399,8 +396,7 @@ TaperedScore Evaluation::EvalPawnsCalculation(const Board &board, COLOR color) {
 TaperedScore Evaluation::EvalRookOpen(const Board& board, COLOR color) {
     TaperedScore score;
     Bitboard bb = board.Piece(color, ROOK);
-    while(bb) {
-        int square = ResetLsb(bb);
+    for(int square : BitboardIterator(bb)) {
         //Semi-open files
         if( IsSemiopenFile(board, color, square) ) {
             score.mg += parameters.ROOK_SEMIOPEN[MG];
@@ -434,9 +430,7 @@ int Evaluation::ClassicalEvaluation(const Board& board) {
         for(PIECE_TYPE pieceType = KNIGHT; pieceType <= KING; ++pieceType) {
               
             Bitboard bb = board.Piece(color, pieceType);
-            while(bb) {
-                int square = ResetLsb(bb);
-
+            for(int square : BitboardIterator(bb)) {
                 //Psqt
                 int index = SQUARE_CONVERSION[color][square];
                 score.Add(

--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -13,79 +13,69 @@ const int MAX_MOVES_RESERVE = 256;
 const int MAX_TACTICAL_MOVES_RESERVE = 64;
 const int MAX_EVASION_MOVES_RESERVE = 64;
 
-//Legal moves
 MoveList MoveGenerator::GenerateMoves(Board &board) {
     if(board.IsCheck()) {
         return GenerateEvasionMoves(board);
     }
 
-    Init(board);
-    m_moves.reserve(MAX_MOVES_RESERVE);
-    m_generateQuiet = true;
-
-    //Calculations
-    m_kingDangerSquares = GenerateKingDangerAttacks(board);
-    m_pinned = PinnedPieces(board, m_color);
-
-    GeneratePseudoMoves(board);
-
+    Generate(board, LEGAL);
     return m_moves;
 }
 
 MoveList MoveGenerator::GenerateEvasionMoves(Board &board) {
-    Init(board);
-    m_moves.reserve(MAX_EVASION_MOVES_RESERVE);
-    m_generateQuiet = true;
-
-    //Calculations
-    m_kingDangerSquares = GenerateKingDangerAttacks(board);
-    m_pinned = PinnedPieces(board, m_color);
-
-    Bitboard checkers = board.Checkers();
-    int numCheckers = PopCount(checkers);
-
-    if(numCheckers > 1) {
-        GenerateKingMoves(board);
-    }
-    else if(numCheckers == 1) {
-        //Create the capture mask
-        m_captureMask = checkers;
-
-        //Create the push mask (block moves)
-        int checkerSquare = BitscanForward(checkers);
-        PIECE_TYPE checkerType = board.GetPieceAtSquare(m_enemyColor, checkerSquare);
-        switch(checkerType) {
-            case PAWN: case KNIGHT: {
-                m_pushMask = ZERO; //only capture solves the check
-            } break;
-            case BISHOP: case ROOK: case QUEEN: {
-                int kingSquare = BitscanForward( board.Piece(m_color, KING) );
-                m_pushMask = Attacks::Between(checkerSquare, kingSquare);
-            } break;
-            default: assert(false);
-        };
-
-        GeneratePseudoMoves(board);
-    }
-
+    Generate(board, EVASION);
     return m_moves;
 }
 
 MoveList MoveGenerator::GenerateTacticalMoves(Board &board) {
-    Init(board);
-    m_moves.reserve(MAX_TACTICAL_MOVES_RESERVE);
-    m_generateQuiet = false;
+    Generate(board, TACTICAL);
+    return m_moves;
+}
 
-    //Calculations
+void MoveGenerator::Generate(Board& board, GENERATION_TYPE type) {
+    Init(board);
+
+    m_generateQuiet = (type == TACTICAL) ? false : true;
     m_kingDangerSquares = GenerateKingDangerAttacks(board);
     m_pinned = PinnedPieces(board, m_color);
 
-    //Don't allow king moves to empty squares
-    m_kingDangerSquares |= ~m_allPieces; // TODO: Pre-optimization not needed.
+    switch(type) {
+        case LEGAL: {
+            m_moves.reserve(MAX_MOVES_RESERVE);
+            break;
+        }
+        case TACTICAL: {
+            m_moves.reserve(MAX_TACTICAL_MOVES_RESERVE);
+            break;
+        }
+        case EVASION: {
+            m_moves.reserve(MAX_EVASION_MOVES_RESERVE);
+
+            Bitboard checkers = board.Checkers();
+            int numCheckers = PopCount(checkers);
+
+            if(numCheckers > 1) {
+                // Double-check, only king moves allowed
+                GenerateKingMoves(board);
+                return;
+            }
+            else if(numCheckers == 1) {
+                m_captureMask = checkers;
+                int checkerSquare = BitscanForward(checkers);
+                PIECE_TYPE checkerType = board.GetPieceAtSquare(m_enemyColor, checkerSquare);
+                if(checkerType == PAWN || checkerType == KNIGHT) {
+                    m_pushMask = ZERO; // No in-between moves are possible
+                } else {
+                    assert((checkerType == BISHOP) || (checkerType == ROOK) || (checkerType == QUEEN));
+                    int kingSquare = BitscanForward( board.Piece(m_color, KING) );
+                    m_pushMask = Attacks::Between(checkerSquare, kingSquare);
+                }
+            }
+            break;
+        }
+    }
 
     GeneratePseudoMoves(board);
-
-    return m_moves;
 }
 
 Move MoveGenerator::RandomMove(const MoveList& moves) {

--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -2,7 +2,6 @@
 #include "Attacks.h"
 using namespace Attacks;
 #include "BitboardUtils.h"
-using namespace BitboardUtils;
 #include "Board.h"
 #include "Utils.h" //random
 
@@ -156,8 +155,7 @@ void MoveGenerator::GeneratePawnMoves(Board &board) {
     singlePush *= m_generateQuiet;
     doublePush *= m_generateQuiet;
 
-    while(singlePush) {
-        int toSq = ResetLsb(singlePush);
+    for(int toSq : BitboardIterator(singlePush)) {
         Bitboard toBitboard = SquareBB(toSq);
         int fromSq = BitscanForward( RSouth(toBitboard) );
         toBitboard &= m_pinnedPushMask[fromSq];
@@ -166,8 +164,7 @@ void MoveGenerator::GeneratePawnMoves(Board &board) {
             m_moves.push_back(move);
         }
     }
-    while(doublePush) {
-        int toSq = ResetLsb(doublePush);
+    for(int toSq : BitboardIterator(doublePush)) {
         Bitboard toBitboard = SquareBB(toSq);
         int fromSq = BitscanForward( RSouth(toBitboard,2) );
         toBitboard &= m_pinnedPushMask[fromSq];
@@ -176,8 +173,7 @@ void MoveGenerator::GeneratePawnMoves(Board &board) {
             m_moves.push_back(move);
         }
     }
-    while(promotionPush) {
-        int toSq = ResetLsb(promotionPush);
+    for(int toSq : BitboardIterator(promotionPush)) {
         Bitboard toBitboard = SquareBB(toSq);
         int fromSq = BitscanForward( RSouth(toBitboard) );
         toBitboard &= m_pinnedPushMask[fromSq];
@@ -190,22 +186,19 @@ void MoveGenerator::GeneratePawnMoves(Board &board) {
                                   : RWest(RSouth(b));
         };
 
-        while(attack[side]) {
-            int toSq = ResetLsb(attack[side]);
+        for(int toSq : BitboardIterator(attack[side])) {
             Bitboard toBitboard = SquareBB(toSq);
             int fromSq = BitscanForward( FromBitboard(toBitboard) );
             toBitboard &= m_pinnedCaptureMask[fromSq];
             AddMoves(board, piece, fromSq, toBitboard);
         }
-        while(promotionAttack[side]) {
-            int toSq = ResetLsb(promotionAttack[side]);
+        for(int toSq : BitboardIterator(promotionAttack[side])) {
             Bitboard toBitboard = SquareBB(toSq);
             int fromSq = BitscanForward( FromBitboard(toBitboard) );
             toBitboard &= m_pinnedCaptureMask[fromSq];
             AddPromotionMoves(board, fromSq, toBitboard);
         }
-        while(enpassant[side]) {
-            int toSq = ResetLsb(enpassant[side]);
+        for(int toSq : BitboardIterator(enpassant[side])) {
             Bitboard toBitboard = SquareBB(toSq);
             int fromSq = BitscanForward( FromBitboard(toBitboard) );
             Bitboard enemyPawn = RSouth(board.EnPassantSquare());
@@ -228,10 +221,8 @@ void MoveGenerator::GenerateKnightMoves(Board &board) {
     Bitboard theKnights = board.GetPieces(m_color, piece);
     theKnights &= ~m_pinned;
 
-    while(theKnights) {
-        int square = ResetLsb(theKnights);
+    for(int square : BitboardIterator(theKnights)) {
         Bitboard attacks = AttacksKnights(square) & ~m_ownPieces;
-
         AddMoves(board, piece, square, attacks);
     }
 }
@@ -259,12 +250,9 @@ void MoveGenerator::GenerateKingMoves(Board &board) {
 void MoveGenerator::GenerateSlidingMoves(PIECE_TYPE pieceType, Board &board) {
     Bitboard thePieces = board.GetPieces(m_color, pieceType);
 
-    while(thePieces) {
-        //Attacks
-        int fromSq = ResetLsb(thePieces);
+    for(int fromSq : BitboardIterator(thePieces)) {
         Bitboard attacks = AttacksSliding(pieceType, fromSq, m_allPieces) & ~m_ownPieces;
         attacks &= m_pinnedPushMask[fromSq] | m_pinnedCaptureMask[fromSq];
-
         AddMoves(board, pieceType, fromSq, attacks);
     }
 }
@@ -278,8 +266,7 @@ void MoveGenerator::AddMoves(Board &board, PIECE_TYPE piece, int fromSq, Bitboar
         captureMoves &= m_captureMask;
     }
 
-    while(captureMoves) {
-        int toSq = ResetLsb(captureMoves);
+    for(int toSq : BitboardIterator(captureMoves)) {
         PIECE_TYPE capturedPiece = board.GetPieceAtSquare(m_enemyColor, toSq);
         Move move = Move(fromSq, toSq, piece, MOVE_TYPE::CAPTURE);
         move.SetCapturedType(capturedPiece);
@@ -289,16 +276,18 @@ void MoveGenerator::AddMoves(Board &board, PIECE_TYPE piece, int fromSq, Bitboar
     // =================================
     // == Normal moves (non-captures) ==
     // =================================
+    if(!m_generateQuiet) {
+        return;
+    }
+
     Bitboard normalMoves = possibleMoves & ~m_enemyPieces;
     if(piece != KING) {
         normalMoves &= m_pushMask;
     }
-    while(normalMoves && m_generateQuiet) {
-        int toSq = ResetLsb(normalMoves);
+    for(int toSq : BitboardIterator(normalMoves)) {
         Move move = Move(fromSq, toSq, piece, MOVE_TYPE::NORMAL);
         m_moves.push_back(move);
     }
-
 }
 
 void MoveGenerator::AddPromotionMoves(Board &board, int fromSq, Bitboard promotionMoves) {
@@ -308,9 +297,7 @@ void MoveGenerator::AddPromotionMoves(Board &board, int fromSq, Bitboard promoti
     promotionMoves &= isCapture ? m_captureMask
                                 : m_pushMask;
 
-    while(promotionMoves) {
-        int toSq = ResetLsb(promotionMoves);
-
+    for(int toSq : BitboardIterator(promotionMoves)) {
         Move move;
         if(isCapture) { //PROMOTION_CAPTURE
             move = Move(fromSq, toSq, PIECE_TYPE::PAWN, MOVE_TYPE::PROMOTION_CAPTURE);
@@ -330,7 +317,6 @@ void MoveGenerator::AddPromotionMoves(Board &board, int fromSq, Bitboard promoti
                 m_moves.push_back(move);
             }
         }
-
     }
 }
 void MoveGenerator::AddCastlingMoves(Board &board) {
@@ -386,15 +372,14 @@ Bitboard MoveGenerator::GenerateKingDangerAttacks(Board &board) {
     Bitboard blockers = m_allPieces ^ board.Piece(m_color, KING);
     for(PIECE_TYPE pieceType = PAWN; pieceType <= KING; ++pieceType) {
         Bitboard enemyPieces = board.Piece(m_enemyColor, pieceType);
-        while(enemyPieces) {
-            int square = ResetLsb(enemyPieces);
+        for(int square : BitboardIterator(enemyPieces)) {
             switch(pieceType) {
-                case PAWN: attacks |= AttacksPawns(m_enemyColor, square); break;
+                case PAWN:   attacks |= AttacksPawns(m_enemyColor, square); break;
                 case KNIGHT: attacks |= AttacksKnights(square); break;
-                case KING: attacks |= AttacksKing(square); break;
+                case KING:   attacks |= AttacksKing(square); break;
                 case BISHOP: attacks |= AttacksSliding(BISHOP, square, blockers); break;
-                case ROOK: attacks |= AttacksSliding(ROOK, square, blockers); break;
-                case QUEEN: attacks |= AttacksSliding(QUEEN, square, blockers); break;
+                case ROOK:   attacks |= AttacksSliding(ROOK, square, blockers); break;
+                case QUEEN:  attacks |= AttacksSliding(QUEEN, square, blockers); break;
                 default: assert(false);
             };
         }
@@ -411,8 +396,7 @@ Bitboard MoveGenerator::PinnedPieces(Board &board, COLOR color) {
 
     for(PIECE_TYPE pieceType : {BISHOP, ROOK, QUEEN}) {
         Bitboard enemySlidings = board.GetPieces(m_enemyColor, pieceType);
-        while(enemySlidings) {
-            int slidingSquare = ResetLsb(enemySlidings);
+        for(int slidingSquare : BitboardIterator(enemySlidings)) {
             switch(pieceType) {
                 case BISHOP: {
                     pinned |= FillPinned(BISHOP, slidingSquare, kingSquare);

--- a/src/NNUE.cpp
+++ b/src/NNUE.cpp
@@ -114,8 +114,7 @@ void NNUE::Inputs_FullUpdate() {
     for(int color = WHITE; color <= BLACK; color++) {
         for(int pieceType = PAWN; pieceType <= QUEEN; pieceType++) {
             Bitboard bitboard = m_pieces[color][pieceType];
-            while(bitboard) {
-                int square = ResetLsb(bitboard);
+            for(int square : BitboardIterator(bitboard)) {
                 Inputs_AddPiece(color, pieceType-1, square);
             }
         }

--- a/src/ZobristKeys.cpp
+++ b/src/ZobristKeys.cpp
@@ -48,8 +48,7 @@ void ZobristKey::SetKey(Board& board) {
         //Pieces
         for(PIECE_TYPE pieceType = PAWN; pieceType <= KING; ++pieceType) {
             Bitboard thePieces = board.GetPieces(color, pieceType);
-            while(thePieces) {
-                int square = ResetLsb(thePieces);
+            for(int square : BitboardIterator(thePieces)) {
                 m_key ^= ZobristKeys::m_zkeyPieces[color][pieceType][square];
             }
         }
@@ -72,8 +71,7 @@ void ZobristKey::SetPawnKey(Board& board) {
 
     for(COLOR color : {WHITE, BLACK}) {
         Bitboard thePawns = board.GetPieces(color, PAWN);
-        while(thePawns) {
-            int square = ResetLsb(thePawns);
+        for(int square : BitboardIterator(thePawns)) {
             m_key ^= ZobristKeys::m_zkeyPieces[color][PAWN][square];
         }
     }


### PR DESCRIPTION
MoveGenerator refactors:
- Add BitboardIterator(b) for better code readability. No performance cost.
- Move Generate() method to encapsulate common logic of the 3 move generators (Legal, Evasions, Tactical).

```
=== BENCHMARK RESULTS ===
Total nodes: 1949471
Total time: 1520 ms
Average speed: 1285.31 kN/s
========================
```