### PR TITLE
bugfix: zkey enpassant

### DIFF
--- a/include/Fen.h
+++ b/include/Fen.h
@@ -6,6 +6,8 @@
 
 class Board;
 
+const std::string INITIAL_POSITION_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
 typedef std::map<std::string, std::string> EPDLine;
 
 class Fen {

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -15,8 +15,6 @@ using namespace BitboardUtils;
 #include <sstream>
 #include <string>
 
-const std::string STARTFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-
 const char PIECE_NOTATION[2][8] = { {' ', 'P', 'N', 'B', 'R', 'Q', 'K', '-',},
                                     {' ', 'p', 'n', 'b', 'r', 'q', 'k', '-'} }; //[COLOR][PIECE]
 
@@ -36,7 +34,7 @@ Board::Board() {
 }
 
 void Board::Init() {
-    SetFen(STARTFEN);
+    SetFen(INITIAL_POSITION_FEN);
 }
 
 u64 Board::Perft(int depth) {

--- a/src/ZobristKeys.cpp
+++ b/src/ZobristKeys.cpp
@@ -62,8 +62,10 @@ void ZobristKey::SetKey(Board& board) {
 
     //Enpassant
     Bitboard epSquare = board.EnPassantSquare();
-    int file = File( BitscanForward(epSquare) );
-    m_key ^= ZobristKeys::m_zkeyEnpassant[file];
+    if(epSquare) {
+        int file = File( BitscanForward(epSquare) );
+        m_key ^= ZobristKeys::m_zkeyEnpassant[file];
+    }
 }
 
 void ZobristKey::SetPawnKey(Board& board) {
@@ -93,6 +95,8 @@ void ZobristKey::UpdateCastling(CASTLING_TYPE castlingType) {
     };
 }
 void ZobristKey::UpdateEnpassant(Bitboard enpassant) {
+    assert(enpassant);
+    
     int file = File( BitscanForward(enpassant) );
     m_key ^= ZobristKeys::m_zkeyEnpassant[file];
 }

--- a/tests/test-Perft.cpp
+++ b/tests/test-Perft.cpp
@@ -23,7 +23,7 @@ TEST(MoveGenerator, StartingPosition) {
 //https://www.chessprogramming.org/Perft_Results
 TEST(Perft, StartingPosition) {
     Board board;
-    // board.SetFen(STARTFEN);
+    // board.SetFen(INITIAL_POSITION_FEN);
     EXPECT_EQ(board.Perft(1), (u64)20);
     EXPECT_EQ(board.Perft(2), (u64)400);
     EXPECT_EQ(board.Perft(3), (u64)8902);

--- a/tests/test-ZobristKey.cpp
+++ b/tests/test-ZobristKey.cpp
@@ -65,7 +65,42 @@ TEST_F(ZobristKeyTest, Castling) {
     EXPECT_EQ(initialKeyCastling, boardCastling.ZKey());
 }
 
-TEST_F(ZobristKeyTest, ZobristAfterPerft) {
+TEST_F(ZobristKeyTest, EnPassant_Fen) {
+    board.SetFen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1");
+    u64 keyNo = board.ZKey();
+
+    board.SetFen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1");
+    u64 keyYes = board.ZKey();
+
+    EXPECT_NE(keyNo, keyYes);
+}
+
+TEST_F(ZobristKeyTest, EnPassant_MakeMove) {
+    Board newBoard; //initial position
+    u64 keyBefore = newBoard.ZKey();
+
+    newBoard.MakeMove("e2e4");
+    newBoard.TakeMove();
+
+    u64 keyAfter = newBoard.ZKey();
+
+    EXPECT_EQ(keyBefore, keyAfter);
+}
+
+TEST_F(ZobristKeyTest, SetFen_vs_MakeMove) {
+    // Position after 1. e4 from FEN
+    board.SetFen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1");
+    u64 zkey_fromFen = board.ZKey();
+
+    // Same position after MakeMove
+    Board newBoard;
+    newBoard.MakeMove("e2e4");
+    u64 zkey_fromMakeMove = newBoard.ZKey();
+
+    EXPECT_EQ(zkey_fromFen, zkey_fromMakeMove);
+}
+
+TEST_F(ZobristKeyTest, AfterPerft) {
     board.Perft(3);
     EXPECT_EQ(initialKey, board.ZKey());
 
@@ -77,13 +112,13 @@ TEST_F(ZobristKeyTest, HashConsistency) {
     Board board1;
     board1.SetFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
     
-    uint64_t hash1 = board1.ZKey();
+    u64 zkey1 = board1.ZKey();
     
     // Run the same position multiple times
     for (int i = 0; i < 10; i++) {
         Board board2;
         board2.SetFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
-        uint64_t hash2 = board2.ZKey();
-        EXPECT_EQ(hash1, hash2) << "Hash inconsistent at iteration " << i;
+        u64 zkey2 = board2.ZKey();
+        EXPECT_EQ(zkey1, zkey2) << "Hash inconsistent at iteration " << i;
     }
 }


### PR DESCRIPTION
Difference between Zobrist Keys from FEN vs MakeMove, when enpassant square is present in the FEN.
Playing strength is not affected. But now the two zkeys are the same from both inputs.