### PR TITLE
fix: nmp: add condition !isPV

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -447,6 +447,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta, bool isPV) {
     // --------- Null-move pruning -----------
     // Skip a move (null move) to quickly detect beta cutoffs
     if(!TURNOFF_NULLMOVE_PRUNING
+        && !isPV
         && !inCheck
         && m_nullmoveAllowed
         && eval >= beta  //very good score


### PR DESCRIPTION
Apply **condition !isPV to Null-Move Pruning**.

Never cutoff PV nodes.

```
=== BENCHMARK RESULTS ===
Total nodes: 1181267 (previous: 1212849)
========================

8s+0.08s / 880 - 876 - 627 [0.501] 2383
Elo difference: 0.6 +/- 12.0, LOS: 53.8 %, DrawRatio: 26.3 %
SPRT: llr 2.99 (101.6%), lbound -2.94, ubound 2.94 - H1 was accepted

40s+0.4s / 191 - 163 - 164 [0.527] 518
Elo difference: 18.8 +/- 24.8, LOS: 93.2 %, DrawRatio: 31.7 %
SPRT: llr 2.99 (101.6%), lbound -2.94, ubound 2.94 - H1 was accepted
```