### PR TITLE
chore: increase bench default depth to 9 (from 8)

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
             ++i; // Skip next argument as it's the path
         }
         else if (arg == "bench") {
-            int depth = 8;
+            int depth = 9;
             if (i + 1 < args.size()) {
                 try {
                     depth = std::stoi(args[i + 1]);

--- a/src/Uci.cpp
+++ b/src/Uci.cpp
@@ -106,7 +106,7 @@ void Uci::Launch() {
             std::cout << "[" << token << " " << depth << "] " << clock.Elapsed() << " ms" << std::endl;
         }
         else if(token == "bench") {
-            int depth = 8; // Default depth
+            int depth = 9; // Default depth
             if(stream >> depth) {
                 std::cout << "Depth provided by user" << std::endl;
             }


### PR DESCRIPTION
Due to latest engine search improvements, **bench depth needs to be increased**.

```
=== BENCHMARK RESULTS ===
Total nodes: 1686292 (previous: 971356, depth 8)
Total time: 1471 ms (previous: 783 ms, depth 8)
========================
```