### PR TITLE
enhancement: incremental aspiration window

### DIFF
--- a/include/Constants.h
+++ b/include/Constants.h
@@ -26,7 +26,8 @@ typedef uint64_t Bitboard;
 #endif
 
 const int INFINITE_SCORE = INFINITE_I16 - 1024;
-const int MATESCORE = INFINITE_SCORE - 1024;
+const int MATESCORE_MAX = INFINITE_SCORE - 1024;
+const int MATESCORE_MIN = MATESCORE_MAX - 1024;
 
 const int MAX_PLY = 2560;
 
@@ -173,8 +174,8 @@ inline PIECE_TYPE& operator++(PIECE_TYPE& pieceType) {
 inline bool IsValidPieceType(PIECE_TYPE piece) {
     return (piece != NO_PIECE) && (piece != ALL_PIECES);
 }
-inline bool IsMateValue(int score) {
-    return (abs(score) <= MATESCORE) && (abs(score) > (MATESCORE - 1024));
+inline bool IsMateValue(const int score) {
+    return (abs(score) >= MATESCORE_MIN) && (abs(score) <= MATESCORE_MAX);
 }
 inline int RelativeRank(COLOR color, int square) {
     return color == WHITE ? Rank(square) : 7 ^ Rank(square);

--- a/include/Search.h
+++ b/include/Search.h
@@ -60,6 +60,7 @@ public:
 
 private:
     // Internal search algorithms
+    int AspirationWindow(Board& board, const int depth, const int bestScore);
     int RootMax(Board &board, int depth, int alpha, int beta);
     int NegaMax(Board  &board, int depth, int alpha, int beta, bool isPV);
     int QuiescenceSearch(Board &board, int alpha, int beta, bool isPV);

--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -25,7 +25,7 @@ TT::~TT() {
 }
 
 void TT::Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth, int ply, int age) {
-    assert(abs(score) <= MATESCORE);
+    assert(abs(score) <= MATESCORE_MAX);
     assert(depth <= MAX_DEPTH);
 
     u64 index = zkey % m_size;
@@ -106,7 +106,7 @@ EvalCache::EvalCache() {
 }
 
 void EvalCache::Store(u64 zkey, int eval) {
-    assert(abs(eval) < MATESCORE);
+    assert(abs(eval) < MATESCORE_MAX);
 
     EvalEntry& entry = m_evalEntries[zkey & m_mask];
 

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -47,12 +47,13 @@ using namespace Sorting;
 #include <format>
 
 // Search parameters
-const int MAX_QS_PLIES = 128;  // Maximum depth limit for quiescence search 
+const int MAX_QS_PLIES = 128;  // Maximum depth limit for quiescence search
 
 // Aspiration window parameters - used to narrow alpha-beta bounds around expected score
-const bool TURNOFF_ASPIRATION_WINDOW = false;
+const bool TURNON_ASPIRATION_WINDOW = true;
 const int ASPIRATION_WINDOW_DEPTH = 4;         // Minimum depth to enable aspiration window
 const int ASPIRATION_WINDOW = 25;              // Initial half-window size in centipawns
+const int ASPIRATION_WINDOW_MULTIPLIER = 2;    // Incremental window resize
 
 const bool TURNOFF_NULLMOVE_PRUNING = false;
 const int NULLMOVE_REDUCTION_FACTOR = 3;
@@ -147,28 +148,8 @@ void Search::IterativeDeepening(Board &board, bool fullSearchClearFlag) {
         assert(m_nullmoveAllowed);
 
         m_selPly = 0;
-        int alpha, beta, score;
 
-        // Aspiration window to narrow alpha-beta bounds around expected score
-        bool aspiration = !TURNOFF_ASPIRATION_WINDOW && m_depth >= ASPIRATION_WINDOW_DEPTH;
-        if(aspiration) {
-            alpha = m_bestScore - ASPIRATION_WINDOW;
-            beta  = m_bestScore + ASPIRATION_WINDOW;
-        } else {
-            alpha = -INFINITE_SCORE;
-            beta  =  INFINITE_SCORE;
-        }
-
-        score = RootMax(board, m_depth, alpha, beta);
-        
-        // Out of aspiration bounds. Repeat search with a wider window
-        while(score <= alpha || score >= beta) {
-            D( m_debug.Increment("IterativeDeepening: AspirationWindow: Out of bounds") );
-
-            alpha = -INFINITE_SCORE;
-            beta  =  INFINITE_SCORE;
-            score = RootMax(board, m_depth, alpha, beta);
-        }
+        AspirationWindow(board, m_depth, m_bestScore);
 
         // Stop search if limits are reached within the loop
         if(m_stop)
@@ -226,8 +207,8 @@ void Search::UciOutput(std::string PV) {
     std::cout << "info depth " << m_depth;
     std::cout << " seldepth " << m_selPly;
     if(IsMateValue(m_bestScore)) {
-        int mateScore = (m_bestScore > 0) ?  MATESCORE - m_bestScore + 1
-                                          : -MATESCORE - m_bestScore - 1;
+        int mateScore = (m_bestScore > 0) ?  MATESCORE_MAX - m_bestScore + 1
+                                          : -MATESCORE_MAX - m_bestScore - 1;
         std::cout << " score mate " << mateScore / 2; //return mate in moves, not in plies
     } else {
         std::cout << " score cp " << m_bestScore;
@@ -256,6 +237,40 @@ void Search::FixNodes(int nodes) {
 }
 void Search::Infinite() {
     m_allocatedTime = INFINITE;
+}
+
+// Narrow alpha-beta bounds around expected score
+int Search::AspirationWindow(Board& board, const int depth, const int bestScore) {
+    const bool aspiration = TURNON_ASPIRATION_WINDOW && depth >= ASPIRATION_WINDOW_DEPTH && !IsMateValue(bestScore);
+    if(!aspiration)
+        return RootMax(board, depth, -INFINITE_SCORE, INFINITE_SCORE);
+
+    int window = ASPIRATION_WINDOW;
+    int alpha = bestScore - window;
+    int beta  = bestScore + window;
+
+    int score = RootMax(board, depth, alpha, beta);
+
+    for(int researches = 1; (score <= alpha || score >= beta); researches++) {
+        D( m_debug.Increment("AspirationWindow: Out of bounds: Researches: " + std::to_string(researches) ); );
+
+        // Asymmetrical incremental aspiration
+        window = window * ASPIRATION_WINDOW_MULTIPLIER;
+        if(score <= alpha) {
+            alpha = bestScore - window;
+        } else if(score >= beta) {
+            beta = bestScore + window;
+        }
+
+        if(researches == 4 || IsMateValue(score)) {
+            alpha = -INFINITE_SCORE;
+            beta = INFINITE_SCORE;
+        }
+
+        score = RootMax(board, depth, alpha, beta);
+    }
+
+    return score;
 }
 
 // Root search. Handle special root-level logic.
@@ -373,8 +388,8 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta, bool isPV) {
     //---------- Mate distance pruning -------------
     // Prevents the search from reporting mates that are too far away
     // TODO: should be different for PV nodes?
-    alpha = std::max(alpha, -MATESCORE + m_ply);
-    beta = std::min(beta, +MATESCORE - m_ply - 1);
+    alpha = std::max(alpha, -MATESCORE_MAX + m_ply);
+    beta = std::min(beta, +MATESCORE_MAX - m_ply - 1);
     if(alpha >= beta) {
         D( m_debug.Increment("NegaMax: Pruning: MateDistance") );
         return alpha;
@@ -491,7 +506,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta, bool isPV) {
     if( moves.empty() ) {
         if(inCheck) {
             D( m_debug.Increment("NegaMax: EmptyMoves: Checkmate") );
-            return -MATESCORE + m_ply; // Checkmate
+            return -MATESCORE_MAX + m_ply; // Checkmate
         }
         else {
             D( m_debug.Increment("NegaMax: EmptyMoves: Stalemate") );
@@ -699,7 +714,7 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta, bool isPV) {
     if( moves.empty() ) {
         if(inCheck) {
             D( m_debug.Increment("Quiescence: EmptyMoves: Checkmate") );
-            return -MATESCORE + m_ply; // Checkmate
+            return -MATESCORE_MAX + m_ply; // Checkmate
         }
         // Generate all the moves to verify stalemate
         else if( MoveGenerator::GenerateMoves(board).size() == 0 ) {

--- a/tests/test-Misc.cpp
+++ b/tests/test-Misc.cpp
@@ -23,7 +23,7 @@ TEST_F(PositionMisc, QuiescenceExplosion) {
     board.SetFen("1QqQqQq1/r6Q/Q6q/q6Q/B2q4/q6Q/k6K/1qQ1QqRb w - -");
     search.FixDepth(1);
     search.IterativeDeepening(board, true);
-    EXPECT_EQ(search.BestScore(), MATESCORE-1);
+    EXPECT_EQ(search.BestScore(), MATESCORE_MAX - 1);
 }
 
 //Mate tests


### PR DESCRIPTION
Asymmetrical **incremental aspiration window**.

New implementation:
- Iteration 0: `score ± window`
- Iteration {1,2,3}: increse the raised bound by `score ± window*2` (incrementally)
- Iteration 4: infinite window
- Special behavior for mate scores

Previous implementation:
- Iteration 0: `score ± window`
- Iteration 1: infinite window

```
=== BENCHMARK RESULTS ===
Total nodes: 1536133 (previous: 1686292)
=========================

Elo   | 19.22 +- 13.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-2.00, 9.00]
Games | N: 1502 W: 546 L: 463 D: 493
Penta | [57, 144, 292, 175, 83]

Elo   | 4.87 +- 6.48 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.70 (-2.94, 2.94) [-2.00, 9.00]
Games | N: 5356 W: 1642 L: 1567 D: 2147
Penta | [164, 594, 1098, 647, 175]
```