### PR TITLE
enhance: PV array

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ set(ENGINE_SOURCES
     src/MoveGenerator.cpp
     src/MoveMaker.cpp
     src/NNUE.cpp
+    src/PV.cpp
     src/Search.cpp
     src/Syzygy.cpp
     src/Uci.cpp

--- a/include/Board.h
+++ b/include/Board.h
@@ -40,7 +40,7 @@ public:
     // Fen
     void SetFen(std::string fenString) { Fen::SetPosition(*this, fenString); }
     std::string SetFenRandom() { return Fen::SetRandomPosition(*this); }
-    std::string GetSimplifiedFen() { return Fen::GetSimplifiedFen(*this); }
+    std::string GetSimplifiedFen() const { return Fen::GetSimplifiedFen(*this); }
 
     // MoveMaker
     void MakeMove(Move move, bool update_nnue = true) { MoveMaker::MakeMove(*this, move, update_nnue); }
@@ -97,8 +97,8 @@ private:
     COLOR m_activePlayer;
     u8 m_castlingRights; //[0-4] bits: the castling rights
     u8 m_fiftyrule;
-    unsigned int m_moveNumber;
-    unsigned int m_ply; //a ply is half a move
+    uint m_moveNumber;
+    uint m_ply; //a ply is half a move
     Bitboard m_enPassantSquare;
     ZobristKey m_zobristKey;
     ZobristKey m_pawnKey;
@@ -112,8 +112,8 @@ private:
     bool m_checkCalculated;
 
     //History
-    unsigned int m_initialPly;
-    BoardHistory m_history[MAX_PLY];
+    uint m_initialPly;
+    BoardHistory m_history[MAX_PLY_HISTORY];
 
     friend class Fen;
     friend class MoveMaker;

--- a/include/Constants.h
+++ b/include/Constants.h
@@ -31,7 +31,8 @@ const int MATESCORE_MIN = MATESCORE_MAX - 1024;
 const int TBWIN = MATESCORE_MIN - 1;
 const int WINSCORE = TBWIN - 1024;
 
-const int MAX_PLY = 2560;
+constexpr int MAX_DEPTH = 128;
+const int MAX_PLY = 256;
 
 enum COLOR { WHITE, BLACK, NO_COLOR };
 enum FILES { FILEA, FILEB, FILEC, FILED, FILEE, FILEF, FILEG, FILEH };

--- a/include/Constants.h
+++ b/include/Constants.h
@@ -33,6 +33,7 @@ const int WINSCORE = TBWIN - 1024;
 
 constexpr int MAX_DEPTH = 128;
 const int MAX_PLY = 256;
+const int MAX_PLY_HISTORY = 2048;
 
 enum COLOR { WHITE, BLACK, NO_COLOR };
 enum FILES { FILEA, FILEB, FILEC, FILED, FILEE, FILEF, FILEG, FILEH };

--- a/include/Fen.h
+++ b/include/Fen.h
@@ -14,7 +14,7 @@ public:
     static void SetPosition(Board& board, std::string fenString);
     static std::string SetRandomPosition(Board& board);
 
-    static std::string GetSimplifiedFen(Board& board);
+    static std::string GetSimplifiedFen(const Board& board);
 
     static EPDLine ReadEPDLine(const std::string& line);
 };

--- a/include/Hash.h
+++ b/include/Hash.h
@@ -3,7 +3,6 @@
 #include "Constants.h"
 #include "Move.h"
 
-constexpr int MAX_DEPTH = 128;
 constexpr uint DEFAULT_HASH_SIZE = 16; //In MegaBytes
 constexpr int PAWN_HASH_SIZE = 8192; //In number of entries
 

--- a/include/Move.h
+++ b/include/Move.h
@@ -15,7 +15,7 @@ public:
     Move();
     Move(u32 from, u32 to, PIECE_TYPE piece, MOVE_TYPE moveType);
 
-    std::string Notation();
+    std::string Notation() const;
     void Print();
 
     inline u32            MoveAsNumber()  const { return                                       m_move; };
@@ -63,9 +63,9 @@ public:
     };
 
 private:
-    std::string IndexToNotation(int index);
-    std::string PieceTypeToNotation(PIECE_TYPE pieceType);
-    std::string DescriptiveNotation();
+    std::string IndexToNotation(int index) const;
+    std::string PieceTypeToNotation(PIECE_TYPE pieceType) const;
+    std::string DescriptiveNotation() const;
 
     void PrintBits32(u32 word, int startBit, int endBit) const;
 

--- a/include/NNUE.h
+++ b/include/NNUE.h
@@ -37,7 +37,7 @@ private:
     Bitboard* m_pieces[2];
     float     m_accumulator[2][NNUE_SIZE];
     //Backups
-    float     m_backupAccumulator[MAX_PLY][2][NNUE_SIZE];
+    float     m_backupAccumulator[MAX_PLY_HISTORY][2][NNUE_SIZE];
 
     bool m_isLoaded;
     std::string m_filepath;

--- a/include/PV.h
+++ b/include/PV.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Constants.h"
+#include "Move.h"
+
+#include <array>
+#include <string>
+
+class PV {
+public:
+    PV();
+    void ClearTable();
+    void ClearPly(int ply);
+
+    void Update(int ply, Move move, int score);
+
+    Move PonderMove() const;
+    std::string PVString() const;
+
+private:
+    using PVLine = std::array<Move, MAX_PLY>;
+    using PVTable = std::array<PVLine, MAX_PLY>;
+
+    PVTable m_pvTable;
+    std::array<int, MAX_PLY> m_pvLength;
+};

--- a/include/Search.h
+++ b/include/Search.h
@@ -5,6 +5,7 @@
 #include "Debug.h"
 #include "Heuristics.h"
 #include "Move.h"
+#include "PV.h"
 #include "Utils.h"
 
 #include <vector>
@@ -81,9 +82,9 @@ private:
     // --- Private variables ---
 
     // Search state
+    PV m_pv;
     int m_bestScore; // Best score found so far for the current search
     Move m_bestMove; // Best move found so far for the current search
-    Move m_ponderMove; // Ponder move (used in UCI output)
     bool m_nullmoveAllowed; // Prevents two consecutive null moves
     u8 m_searchCount; // Used as 'age' in transposition tables
     // Nodes

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -113,6 +113,8 @@ void Board::Print(bool bits) const {
         }
         square++;
     }
+
+    std::cout << "FEN (simplified): " << GetSimplifiedFen() << std::endl;
 }
 
 void Board::ShowHashMoves() {
@@ -406,7 +408,7 @@ void Board::ClearBits() {
         }
     }
 
-    for(int i = 0; i < MAX_PLY; ++i) {
+    for(int i = 0; i < MAX_PLY_HISTORY; ++i) {
         m_history[i].Clear();
     }
 

--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -70,7 +70,7 @@ bool BoardIntegrityChecker::CheckIntegrity(const Board& board) {
         PopCount( board.Piece(WHITE, PAWN) ) <= 8 &&
         PopCount( board.Piece(BLACK, PAWN) ) <= 8 &&
         PopCount( board.EnPassantSquare() ) <= 1 &&
-        board.Ply() <= MAX_PLY &&
+        board.Ply() < MAX_PLY_HISTORY &&
         board.ActivePlayer() != NO_COLOR;
 }
 

--- a/src/Fen.cpp
+++ b/src/Fen.cpp
@@ -168,7 +168,7 @@ std::string Fen::SetRandomPosition(Board& board) {
 }
 
 //Fen with only the piece positions (without side-to-move, castling rights...)
-std::string Fen::GetSimplifiedFen(Board& board) {
+std::string Fen::GetSimplifiedFen(const Board& board) {
     std::string buffer = ""; //buffer to fill the fen
     int empties = 0; //number of successive empty squares
 

--- a/src/Move.cpp
+++ b/src/Move.cpp
@@ -16,7 +16,7 @@ Move::Move(u32 from, u32 to, PIECE_TYPE piece, MOVE_TYPE moveType) : m_move(0) {
         | PushBits(moveType, 3, 15);
 }
 
-std::string Move::Notation() {
+std::string Move::Notation() const {
     if( MoveType() == NULLMOVE ) return "0000";
     
     const bool useDescriptive = true;
@@ -62,7 +62,7 @@ std::string Move::Notation() {
     return prefix + IndexToNotation(data.toSq) + promotionSuffix;
 }
 
-std::string Move::DescriptiveNotation() {
+std::string Move::DescriptiveNotation() const {
     MoveData data = Data();
 
     //Promotion suffix
@@ -81,12 +81,12 @@ std::string Move::DescriptiveNotation() {
     return IndexToNotation(data.fromSq) + IndexToNotation(data.toSq) + promotionSuffix;
 }
 
-std::string Move::IndexToNotation(int index) {
+std::string Move::IndexToNotation(int index) const {
     char file = FILES_NOTATION[index % 8];
     char rank = RANKS_NOTATION[index / 8];
     return std::string({file, rank});
 }
-std::string Move::PieceTypeToNotation(PIECE_TYPE pieceType) {
+std::string Move::PieceTypeToNotation(PIECE_TYPE pieceType) const {
     return std::string({PIECES_NOTATION[pieceType]});
 }
 

--- a/src/MoveMaker.cpp
+++ b/src/MoveMaker.cpp
@@ -21,15 +21,14 @@ void MoveMaker::MakeMove(Board& board, Move move, bool update_nnue) {
         nnue.SavePosition(board.m_ply);
 
     //Increase ply
-    ++board.m_ply;
-    if(color == BLACK) {
-        ++board.m_moveNumber;
-    }
+    board.m_ply++;
+    if(color == BLACK)
+        board.m_moveNumber++;
     //Fifty-rule
     if(pieceType == PAWN || moveType == CAPTURE) {
         board.m_fiftyrule = 0;
     } else {
-        ++board.m_fiftyrule;
+        board.m_fiftyrule++;
     }
 
     //Reset en-passant square
@@ -75,7 +74,7 @@ void MoveMaker::MakeMove(Board& board, Move move, bool update_nnue) {
     board.m_zobristKey.UpdateColor();
 
     //Store irreversible information (to help a later TakeMove)
-    assert(board.m_ply <= MAX_PLY);
+    assert(board.m_ply < MAX_PLY_HISTORY);
     board.m_history[board.m_ply].fiftyrule = board.m_fiftyrule;
     board.m_history[board.m_ply].castling = board.m_castlingRights;
     board.m_history[board.m_ply].zkey = board.ZKey();
@@ -193,7 +192,7 @@ void MoveMaker::MakeNull(Board& board) {
     Move move = Move();
 
     board.m_ply++;
-    assert(board.m_ply <= MAX_PLY);
+    assert(board.m_ply < MAX_PLY_HISTORY);
 
     //Reset en-passant square
     if(board.m_enPassantSquare) {

--- a/src/PV.cpp
+++ b/src/PV.cpp
@@ -1,0 +1,43 @@
+#include "PV.h"
+
+PV::PV() {
+    ClearTable();
+}
+
+void PV::ClearTable() {
+    for(int i = 0; i < MAX_PLY; ++i) {
+        ClearPly(i);
+    }
+}
+
+// Clear the PV for the current ply
+void PV::ClearPly(int ply) {
+    assert(ply >= 0 && ply < MAX_PLY);
+    m_pvLength[ply] = 0;
+}
+
+void PV::Update(int ply, Move move, [[maybe_unused]] int score) {
+    m_pvTable[ply][0] = move;
+
+    const int childPly = ply + 1;
+    for(int i = 0; i < m_pvLength[childPly]; ++i) {
+        m_pvTable[ply][i + 1] = m_pvTable[childPly][i];
+    }
+
+    m_pvLength[ply] = m_pvLength[childPly] + 1;
+}
+
+Move PV::PonderMove() const {
+    if(m_pvLength[0] > 1)
+        return m_pvTable[0][1];
+    return Move();
+}
+
+std::string PV::PVString() const {
+    std::string pv;
+    for(int i = 0; i < m_pvLength[0]; ++i) {
+        pv += m_pvTable[0][i].Notation();
+        pv += " ";
+    }
+    return pv;
+}

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -94,7 +94,7 @@ Search::Search() {
 
 // Reset state for a new position search.
 // Called at the beginning of each iteration in Iterative Deepening.
-void Search::ClearSearch(bool fullSearchClearFlag) {
+void Search::ClearSearch(bool fullClear) {
     // Node counters
     m_nodes = 0;
     m_nps = 0;
@@ -106,6 +106,7 @@ void Search::ClearSearch(bool fullSearchClearFlag) {
     m_nodesTimeCheck = 0;
 
     // Search state
+    m_pv.ClearTable();
     m_bestScore = -INFINITE_SCORE;
     m_bestMove = Move();
 
@@ -125,7 +126,7 @@ void Search::ClearSearch(bool fullSearchClearFlag) {
     m_debug.Clear();
 
     // Completely clear TT and history heuristics for a reproducible search
-    if(fullSearchClearFlag) {
+    if(fullClear) {
         Hash::tt.Clear();
         Hash::evalCache.Clear();
         Hash::pawnHash.Clear();
@@ -136,10 +137,10 @@ void Search::ClearSearch(bool fullSearchClearFlag) {
 
 // Main loop: increase depth one by one and call the root search.
 // Manage time, aspiration window, and UCI output.
-void Search::IterativeDeepening(Board &board, bool fullSearchClearFlag) {
+void Search::IterativeDeepening(Board &board, bool fullClear) {
     m_clock.Start();
 
-    ClearSearch(fullSearchClearFlag);
+    ClearSearch(fullClear);
     
     D( m_debug.Increment("IterativeDeepening: _: Start") );
     m_searchCount++;
@@ -161,37 +162,14 @@ void Search::IterativeDeepening(Board &board, bool fullSearchClearFlag) {
         m_elapsedTime = ElapsedTime();
         m_nps = static_cast<int>(1000 * m_nodes / (m_elapsedTime+1));
 
-        // Build principal variation (PV) line from transposition table
-        std::string PV;
-        m_ponderMove = Move();
-        Board newBoard = board;
-        D(
-            BoardIdentity bef = BoardIntegrityChecker::GenerateBoardIdentity(board);
-            BoardIdentity aft = BoardIntegrityChecker::GenerateBoardIdentity(newBoard);
-            assert(bef == aft);
-        );
-        for(int depth = 1; depth <= m_depth; depth++) {
-            TTEntry *ttEntry = Hash::tt.Probe(newBoard.ZKey(), 0);
-            if(!ttEntry) continue;
-            if(ttEntry->bestMove.MoveType() == NULLMOVE) break;
-
-            Move bestMove = ttEntry->bestMove;
-            PV += bestMove.Notation();
-            PV += " ";
-
-            if(depth == 2)
-                m_ponderMove = bestMove;
-
-            newBoard.MakeMove(bestMove, false);
-        }
-
+        // PV
         if(UCI_OUTPUT)
-            UciOutput(PV);
+            UciOutput(m_pv.PVString());
 
         // Stop search if we used half of the allocated time, since
         // next iteration will likely use more than the allocated time
         if(m_elapsedTime > (m_allocatedTime / 2)) //check
-             break;
+            break;
 
         if(DEBUG_PRINT_STATISTICS && m_depth == m_maxDepth)
             D( m_debug.Print() );
@@ -200,7 +178,7 @@ void Search::IterativeDeepening(Board &board, bool fullSearchClearFlag) {
     if(UCI_OUTPUT) {
         std::cout << "bestmove " << m_bestMove.Notation();
         if(UCI_PONDER)
-            std::cout << " ponder " << m_ponderMove.Notation();
+            std::cout << " ponder " << m_pv.PonderMove().Notation();
         std::cout << std::endl;
     }
 }
@@ -220,6 +198,8 @@ void Search::UciOutput(std::string PV) {
     std::cout << " nps " << m_nps;
     if(m_elapsedTime > 1000)
         std::cout << " hashfull " << Hash::tt.Occupancy();
+    if(m_tbHits)
+        std::cout << " tbhits " << m_tbHits;
     std::cout << " pv " << PV;
     std::cout << std::endl;
 }
@@ -286,6 +266,7 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
     Move bestMove;
     int score;
 
+    m_pv.ClearPly(m_ply);
     int alphaOriginal = alpha; // Save the original alpha for TT logic
 
     MoveList moves = MoveGenerator::GenerateMoves(board);
@@ -295,6 +276,7 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
     SortMoves(board, moves, Hash::tt, m_heuristics, m_ply);
 
     int moveNumber = 0;
+
     for(auto move : moves) {
         moveNumber++;
         bool isPV = (moveNumber == 1);
@@ -323,9 +305,8 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
             score = -NegaMax(board, depth-1, -alpha-1, -alpha, false);
 
             // Score within window: new PV found! Re-search with full window
-            if(score > alpha && score < beta) {
+            if(score > alpha && score < beta)
                 score = -NegaMax(board, depth-1, -beta, -alpha, true);
-            }
         }
 
         board.TakeMove(move);
@@ -335,6 +316,8 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
             D( m_debug.Increment("RootMax: AlphaBeta: Update: BestMove (score > alpha)") );
             alpha = score;
             bestMove = move;
+
+            m_pv.Update(m_ply, move, score);
         }
 
         // Not useful to store in TT due to aspiration window
@@ -369,6 +352,8 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta, bool isPV) {
     assert(m_ply <= MAX_PLY);
 
     D( m_debug.Increment("NegaMax: _: Entering function") );
+
+    m_pv.ClearPly(m_ply);
 
     // --------- Termination checks -----------
     m_nodesTimeCheck++;
@@ -564,6 +549,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta, bool isPV) {
 
     // --------- Move loop ---------
     int moveNumber = 0;
+
     for(auto move : moves) {
         assert(move.MoveType());
 
@@ -635,13 +621,12 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta, bool isPV) {
             score = -NegaMax(board, reducedDepth, -alpha-1, -alpha, false);
 
             // Reduced search failed high: re-search with full depth
-            if(reduction && score > alpha) {
+            if(reduction && score > alpha)
                 score = -NegaMax(board, fullDepth, -alpha-1, -alpha, false);
-            }
+
             // Score within window: new PV found! Re-search with full window and depth
-            if(score > alpha && score < beta) { // 'score < beta' needed in fail-soft schemes
+            if(score > alpha && score < beta) // 'score < beta' needed in fail-soft schemes
                 score = -NegaMax(board, fullDepth, -beta, -alpha, true);
-            }
         }
 
         board.TakeMove(move);
@@ -670,6 +655,8 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta, bool isPV) {
         if(score > alpha) {
             D( m_debug.Increment("NegaMax: AlphaBeta: Update: Alpha") );
             alpha = score;
+ 
+            m_pv.Update(m_ply, move, score);
         }
 
     } // End move loop

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -349,7 +349,7 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
 // Implements most of the engine's search logic.
 int Search::NegaMax(Board &board, int depth, int alpha, int beta, bool isPV) {
     assert(alpha >= -INFINITE_SCORE && beta <= INFINITE_SCORE && alpha < beta);
-    assert(m_ply <= MAX_PLY);
+    assert(m_ply < MAX_PLY);
 
     D( m_debug.Increment("NegaMax: _: Entering function") );
 
@@ -678,7 +678,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta, bool isPV) {
 // in tactical sequences (captures and checks).
 int Search::QuiescenceSearch(Board &board, int alpha, int beta, bool isPV) {
     assert(alpha >= -INFINITE_SCORE && beta <= INFINITE_SCORE && alpha < beta);
-    assert(m_ply <= MAX_PLY);
+    assert(m_ply < MAX_PLY);
 
     D( m_debug.Increment("Quiescence: _: Hits"); );
     D( if(m_plyqs <= 2 || m_plyqs % 5 == 0) m_debug.Increment("Quiescence: QPly " + std::format("{:03}", m_plyqs)) );

--- a/src/Uci.cpp
+++ b/src/Uci.cpp
@@ -120,16 +120,18 @@ void Uci::Launch() {
         else if(token == "print") {
             m_board.Print();
             std::string activePlayer = (m_board.ActivePlayer() == WHITE) ? "WHITE" : "BLACK";
+            P("Active player: " << activePlayer);
+            P("Ply: " << m_board.Ply());
+            P("Fifty-move rule: " << m_board.FiftyRule());
             std::string castlingRights;
             if(m_board.CastlingRights() & 0b0001) castlingRights += "K"; else castlingRights += "-";
             if(m_board.CastlingRights() & 0b0010) castlingRights += "Q"; else castlingRights += "-";
             if(m_board.CastlingRights() & 0b0100) castlingRights += "k"; else castlingRights += "-";
             if(m_board.CastlingRights() & 0b1000) castlingRights += "q"; else castlingRights += "-";
-            P("Active player: " << activePlayer);
-            P("Ply: " << m_board.Ply());
-            P("Fifty-move rule: " << m_board.FiftyRule());
             P("Castling rights: " << castlingRights);
-            P("Enpassant square: " << BitscanForward(m_board.EnPassantSquare()));
+            Bitboard enpassant = m_board.EnPassantSquare();
+            int epSquare = enpassant ? BitscanForward(enpassant) : -1;
+            P("Enpassant square: " << epSquare);
             P("ZKey: " << m_board.ZKey());
             P("Static evaluation: " << Evaluation::Evaluate(m_board));
             std::cout << "Move history: "; m_board.ShowHistory(); std::cout << std::endl;


### PR DESCRIPTION
**Store PV** in triangle arrays for UCI report.

The previous method used the TT and make/take moves, but that method was not working in positions with high number of `tb_hits`.

```
=== BENCHMARK RESULTS ===
Total nodes: 1577155
=========================

Elo   | 7.26 +- 13.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1388 W: 468 L: 439 D: 481
Penta | [49, 151, 271, 168, 55]
```