### PR TITLE
enhance: tt improvements

### DIFF
--- a/include/BitboardUtils.h
+++ b/include/BitboardUtils.h
@@ -33,6 +33,14 @@ namespace BitboardUtils {
         return (input & BitMask(width, startIndex)) >> startIndex;
     }
 
+    //First bits of the input number (16 if u16)
+    template<typename T>
+    constexpr T UpperBits(u64 input) {
+        constexpr int numBits = sizeof(T) * 8;
+        constexpr int shift = 64 - numBits;
+        return static_cast<T>(input >> shift);
+    }
+
     int BitscanForward(Bitboard b);
     int BitscanReverse(Bitboard b);
     int PopCount(Bitboard b);

--- a/include/Hash.h
+++ b/include/Hash.h
@@ -6,8 +6,8 @@
 constexpr uint DEFAULT_HASH_SIZE = 16; //In MegaBytes
 constexpr int PAWN_HASH_SIZE = 8192; //In number of entries
 
-// 2 MB / 64 bits per entry = 2^18 entries
-constexpr uint EVALCACHE_ENTRIES = 1 << 18;
+// 2^19 entries = 2 MB / 32 bits per entry
+constexpr u64 EVALCACHE_ENTRIES = 1 << 19;
 
 // =========================
 // == Transposition table ==
@@ -47,7 +47,6 @@ public:
 
 private:
     int ScoreToHash(int score, int ply);
-    static u32 UpperBits(u64 zkey);
 
     TTEntry* m_entries;
     u64 m_size; // Number of entries
@@ -58,9 +57,9 @@ private:
 // == Eval cache ==
 // ================
 
-// 32(zkey) + 16(eval) + 16(padding) = 64 bits per entry
+// 16(zkey) + 16(eval) = 32 bits per entry
 struct EvalEntry {
-    u32 zkey32;
+    u16 zkey;
     i16 eval;
 };
 

--- a/include/Hash.h
+++ b/include/Hash.h
@@ -39,7 +39,7 @@ public:
     TTEntry* Probe(u64 zkey, int depth);
 
     void Clear();
-    void SetSize(int size);
+    void SetSize(int sizeInMB);
 
     u64 Size() { return m_size; };
     u64 Occupancy(u64 sampleSize = 1000) const;
@@ -51,6 +51,7 @@ private:
 
     TTEntry* m_entries;
     u64 m_size; // Number of entries
+    u64 m_mask; // Mask for AND operations
 };
 
 // ================

--- a/include/Hash.h
+++ b/include/Hash.h
@@ -17,9 +17,10 @@ constexpr uint EVALCACHE_ENTRIES = 1 << 18;
 // Beta node: the true eval is at least equal to the score (true >= score) LOWER_BOUND
 enum class TTENTRY_TYPE : u8 { NONE, EXACT, LOWER_BOUND, UPPER_BOUND };
 
-// 64(zkey) + 32(move) + 16(score) + 8(depth) + 2(type) + 6(age) = 128 bits per entry
+// 32(zkey) + 32(move) + 16(score) + 8(depth) + 2(type) + 6(age) + 32(padding) = 128 bits per entry
 struct TTEntry {
-    u64 zkey;
+    u32 zkey;
+    u32 padding;
     i16 score;
     u8 depth;
     TTENTRY_TYPE type : 2;
@@ -46,6 +47,7 @@ public:
 
 private:
     int ScoreToHash(int score, int ply);
+    static u32 UpperBits(u64 zkey);
 
     TTEntry* m_entries;
     u64 m_size; // Number of entries

--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -2,6 +2,8 @@
 
 #include "Debug.h"
 
+#include <bit>
+
 // =========================
 // == Transposition table ==
 // =========================
@@ -28,7 +30,7 @@ void TT::Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth,
     assert(abs(score) <= MATESCORE_MAX);
     assert(depth <= MAX_DEPTH);
 
-    u64 index = zkey % m_size;
+    u64 index = zkey & m_mask;
     TTEntry* entry = &m_entries[index];
 
     //Replacement scheme
@@ -45,7 +47,7 @@ void TT::Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth,
 }
 
 TTEntry* TT::Probe(u64 zkey, int depth) {
-    u64 index = zkey % m_size;
+    u64 index = zkey & m_mask;
     TTEntry* entry = &m_entries[index];
 
     const bool zkeyEqual = UpperBits(zkey) == entry->zkey;
@@ -63,12 +65,16 @@ void TT::Clear() {
     }
 }
 
-void TT::SetSize(int size) {  // size in MB
-    m_size = size * (1024*1024) / sizeof(TTEntry);
+// For a faster entry lookup using a mask: downsize entries (m_size) to fill in a power of 2
+void TT::SetSize(int sizeInMB) {
+    u64 maxEntries = sizeInMB * (1024 * 1024) / sizeof(TTEntry);
+
+    m_size = std::bit_floor(maxEntries);
+    m_mask = m_size - 1;
 
     delete [] m_entries;
     m_entries = new TTEntry[m_size];
-    
+
     Clear();
 }
 

--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -37,7 +37,7 @@ void TT::Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth,
     const bool older = age != entry-> age;
     const bool higherDepth = depth >= entry->depth;
     if(older || higherDepth) {
-        entry->zkey = UpperBits(zkey);
+        entry->zkey = UpperBits<u32>(zkey);
         entry->score = SafeCastInt16( ScoreToHash(score, ply) );
         entry->depth = SafeCastU8(depth);
         entry->type = type;
@@ -50,7 +50,7 @@ TTEntry* TT::Probe(u64 zkey, int depth) {
     u64 index = zkey & m_mask;
     TTEntry* entry = &m_entries[index];
 
-    const bool zkeyEqual = UpperBits(zkey) == entry->zkey;
+    const bool zkeyEqual = UpperBits<u32>(zkey) == entry->zkey;
     const bool higherDepth = entry->depth >= depth;
     if(zkeyEqual && higherDepth) {
         return entry;
@@ -86,10 +86,6 @@ u64 TT::Occupancy(u64 sampleSize) const {
     return count;
 }
 
-u32 TT::UpperBits(u64 zkey) {
-    return static_cast<u32>(zkey >> 32);
-}
-
 //Translate mate scores as relative from the root (ROOT')
 //ROOT' <---- (Mate in X+ply') <---- POS <---- (Mate in X)
 int TT::ScoreFromHash(int score, int ply) {
@@ -117,6 +113,8 @@ int TT::ScoreToHash(int score, int ply) {
 // ================
 
 EvalCache::EvalCache() {
+    static_assert( std::has_single_bit(EVALCACHE_ENTRIES), "EVALCACHE_ENTRIES should be a power of 2." );
+
     m_size = EVALCACHE_ENTRIES;
     m_mask = m_size - 1;
     Clear();
@@ -125,18 +123,19 @@ EvalCache::EvalCache() {
 void EvalCache::Store(u64 zkey, int eval) {
     assert(abs(eval) < MATESCORE_MAX);
 
-    EvalEntry& entry = m_evalEntries[zkey & m_mask];
+    u64 index = zkey & m_mask;
+    EvalEntry& entry = m_evalEntries[index];
 
     // Always-replace strategy
-    entry.zkey32 = static_cast<u32>(zkey);
+    entry.zkey = UpperBits<u16>(zkey);
     entry.eval = SafeCastInt16(eval);
 }
 
 bool EvalCache::Probe(u64 zkey, int& eval) {
-    u32 key32 = static_cast<u32>(zkey);
-    EvalEntry& entry = m_evalEntries[zkey & m_mask];
+    u64 index = zkey & m_mask;
+    EvalEntry& entry = m_evalEntries[index];
 
-    if(entry.zkey32 == key32) {
+    if(entry.zkey == UpperBits<u16>(zkey)) {
         eval = entry.eval;
         return true;
     }
@@ -152,7 +151,7 @@ void EvalCache::Clear() {
 u64 EvalCache::Occupancy(u64 sampleSize) const {
     u64 count = 0;
     for(u64 i = 0; i < sampleSize; ++i) {
-        count += (m_evalEntries[i].zkey32 != 0);
+        count += (m_evalEntries[i].zkey != 0);
     }
     return count;
 }

--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -32,8 +32,10 @@ void TT::Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth,
     TTEntry* entry = &m_entries[index];
 
     //Replacement scheme
-    if(age != entry->age || depth >= entry->depth) {
-        entry->zkey = zkey;
+    const bool older = age != entry-> age;
+    const bool higherDepth = depth >= entry->depth;
+    if(older || higherDepth) {
+        entry->zkey = UpperBits(zkey);
         entry->score = SafeCastInt16( ScoreToHash(score, ply) );
         entry->depth = SafeCastU8(depth);
         entry->type = type;
@@ -45,7 +47,10 @@ void TT::Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth,
 TTEntry* TT::Probe(u64 zkey, int depth) {
     u64 index = zkey % m_size;
     TTEntry* entry = &m_entries[index];
-    if(entry->zkey == zkey && entry->depth >= depth) {
+
+    const bool zkeyEqual = UpperBits(zkey) == entry->zkey;
+    const bool higherDepth = entry->depth >= depth;
+    if(zkeyEqual && higherDepth) {
         return entry;
     } else {
         return nullptr;
@@ -73,6 +78,10 @@ u64 TT::Occupancy(u64 sampleSize) const {
         count += (m_entries[i].zkey != 0);
     }
     return count;
+}
+
+u32 TT::UpperBits(u64 zkey) {
+    return static_cast<u32>(zkey >> 32);
 }
 
 //Translate mate scores as relative from the root (ROOT')

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -805,8 +805,10 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
         if(score > bestScore)
             bestScore = score;
 
-        if(score >= beta)
+        if(score >= beta) {
+            Hash::tt.Store(board.ZKey(), bestScore, TTENTRY_TYPE::LOWER_BOUND, move, 0, m_ply, m_searchCount);
             return score;
+        }
 
         if(score > alpha)
             alpha = score;


### PR DESCRIPTION
**Several TT improvements**.

Functional:
- In qsearch, store lower bounds in TT.
- Use 16-bit partial zkeys in Evaluation cache. This allows to shrink the entry to 32-bits (from 64), effectively doubling the number of entries. Still, this cache is useful only in short-time controls.

Non-functional:
- In TT, force power of 2 entries to access index using a mask.
- Use 32-bit partial zkeys in TT. The extra 32-bits are left empty for now, but could be used to store new information: static eval, PV boolean, etc.

```
=== BENCHMARK RESULTS ===
Total nodes: 1840678 (previous: 1900127)
=========================

Elo   | 4.79 +- 11.59 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1668 W: 516 L: 493 D: 659
Penta | [46, 195, 340, 196, 57]
```