### PR TITLE
refactor: move scorer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ set(ENGINE_SOURCES
     src/Move.cpp
     src/MoveGenerator.cpp
     src/MoveMaker.cpp
+    src/MoveScorer.cpp
     src/NNUE.cpp
     src/PV.cpp
     src/Search.cpp

--- a/include/Constants.h
+++ b/include/Constants.h
@@ -35,6 +35,10 @@ constexpr int MAX_DEPTH = 128;
 const int MAX_PLY = 256;
 const int MAX_PLY_HISTORY = 2048;
 
+namespace SEE{
+    constexpr int MATERIAL_VALUES[8] = {0, 100, 350, 350, 500, 1050, 0}; // [PIECE]
+}
+
 enum COLOR { WHITE, BLACK, NO_COLOR };
 enum FILES { FILEA, FILEB, FILEC, FILED, FILEE, FILEF, FILEG, FILEH };
 enum RANKS { RANK1, RANK2, RANK3, RANK4, RANK5, RANK6, RANK7, RANK8 };

--- a/include/Heuristics.h
+++ b/include/Heuristics.h
@@ -10,21 +10,6 @@ struct Heuristics;
 const int HEURISTICS_MAX_PLY = 128;
 const int VALUE_TO_RESET_HISTORY = INFINITE / 512;
 
-namespace SEE {
-    constexpr int MATERIAL_VALUES[8] = {0, 100, 350, 350, 500, 1050, 0}; // [PIECE]
-
-    const int MIN_SCORE = 1;
-    const int MAX_SCORE = 253;
-    constexpr int SCORE_RANGE = MAX_SCORE - MIN_SCORE;
-    constexpr int ZERO_SCORE = (MIN_SCORE + MAX_SCORE) / 2; // Equivalent to SEE = 0 (neutral capture)
-    
-    constexpr int SEE_MAX = MATERIAL_VALUES[QUEEN];
-    constexpr int SEE_RANGE = SEE_MAX * 2;
-
-    int FromScore(u8 score);
-    u8 ToScore(int see);
-}
-
 namespace Sorting {
     void SortMoves(Board &board, MoveList &moves, TT& tt, const Heuristics &heuristics, int ply);
     void SortEvasions(Board &board, MoveList &moves);

--- a/include/Move.h
+++ b/include/Move.h
@@ -2,7 +2,7 @@
 
 #include "Constants.h"
 #include "BitboardUtils.h"
-#include <vector>
+#include "MoveScorer.h"
 
 enum MOVE_TYPE { NULLMOVE, NORMAL, CAPTURE, CASTLING, PROMOTION, DOUBLE_PUSH, PROMOTION_CAPTURE, ENPASSANT }; //CAPTURE + PROMOTION = PROMOTION_CAPTURE
 enum PROMOTION_TYPE { PROMOTION_QUEEN, PROMOTION_KNIGHT, PROMOTION_ROOK, PROMOTION_BISHOP };
@@ -61,6 +61,9 @@ public:
     bool operator!=(const Move& rmove) const {
         return !(*this == rmove);
     };
+
+    // Scorer methods
+    bool IsNegativeCapture() const { return Scorer::IsNegativeCapture(this->Score()); };
 
 private:
     std::string IndexToNotation(int index) const;

--- a/include/MoveScorer.h
+++ b/include/MoveScorer.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "Constants.h"
+
+namespace Scorer {
+
+    // Normal positions
+    constexpr int HASH = 255;
+    constexpr int PROMOTION_CAPTURE = 254;
+    constexpr int PROMOTION = 253;
+    constexpr int POSITIVECAPTURE_MAX = 249;
+    constexpr int POSITIVECAPTURE_MIN = 241;
+    constexpr int NEUTRALCAPTURE = 240;
+    constexpr int NEUTRALCAPTURE_MAX = 240;
+    constexpr int NEUTRALCAPTURE_MIN = 240;
+    constexpr int KILLER_1 = 194;
+    constexpr int KILLER_2 = 193;
+    constexpr int KILLER_3 = 192;
+    constexpr int KILLER_4 = 191;
+    constexpr int NEGATIVECAPTURE_MAX = 189;
+    constexpr int NEGATIVECAPTURE_MIN = 181;
+    constexpr int HISTORY_MAX = 180;
+    constexpr int HISTORY_MIN = 1;
+    constexpr int UNDERPROMOTION = 0;
+    u8 ScoreFromHistory(int historyValue, int historyMax);
+    u8 ScoreFromSEE(int see);
+
+    // Tactical positions
+    constexpr int TACTICAL_PROMOTION_CAPTURE = 255;
+    constexpr int TACTICAL_PROMOTION_NORMAL = 254;
+    constexpr int TACTICAL_MAX = 253;
+    constexpr int TACTICAL_MIN = 1;
+    u8 TacticalScoreFromSEE(int see);
+    int SEEFromTacticalScore(u8 score);
+
+    // Check evasion positions
+    constexpr int EVASION_CAPTURE = 1;
+    constexpr int EVASION_NORMAL = 0;
+
+    // Single methods
+
+    inline bool IsNeutralCapture(int score) {
+        return score == NEUTRALCAPTURE;
+    }
+
+    inline bool IsNegativeCapture(int score) {
+        return score >= NEGATIVECAPTURE_MIN
+            && score <= NEGATIVECAPTURE_MAX;
+    }
+
+    inline bool IsHistoryMove(int score) {
+        return score >= HISTORY_MIN
+            && score <= HISTORY_MAX;
+    }
+
+    // Composite methods
+    
+    inline bool IsNegativeOrNeutral(int score) {
+        return IsNeutralCapture(score) || IsNegativeCapture(score);
+    }
+}

--- a/src/Heuristics.cpp
+++ b/src/Heuristics.cpp
@@ -3,6 +3,7 @@
 #include "Board.h"
 #include "Evaluation.h"
 #include "Hash.h"
+#include "MoveScorer.h"
 #include "Search.h"
 
 #include <algorithm>
@@ -13,9 +14,8 @@ namespace {
     void RateMoves(Board &board, MoveList &moves, TT& tt, const Heuristics &heuristics, int ply) {
         Move hashMove;
         TTEntry* ttEntry = tt.Probe(board.ZKey(), 0); //shallowest
-        if(ttEntry) {
+        if(ttEntry)
             hashMove = ttEntry->bestMove;
-        }
 
         Move killer1 = heuristics.killer.Primary(ply);
         Move killer2 = heuristics.killer.Secondary(ply);
@@ -27,108 +27,70 @@ namespace {
 
         for(auto& move : moves) {
 
-            //Hash move: 255 (max)
+            // Hash move: max score
             if(move == hashMove) {
-                move.SetScore(255);
+                move.SetScore(Scorer::HASH);
                 continue;
             }
 
-            //Queen promotion captures: 254
-            //Queen promotions: 253
-            //Underpromotions: 0
+            // Promotions
             if(move.IsPromotion()) {
                 if(move.MoveType() == PROMOTION_CAPTURE && move.PromotionType() == PROMOTION_QUEEN) {
-                    move.SetScore(254); continue;
+                    move.SetScore(Scorer::PROMOTION_CAPTURE);
+                    continue;
                 }
                 else if(move.MoveType() == PROMOTION && move.PromotionType() == PROMOTION_QUEEN) {
-                    move.SetScore(253); continue;
+                    move.SetScore(Scorer::PROMOTION);
+                    continue;
                 }
-                else { //underpromotion
-                    move.SetScore(0); continue;
-                }
-            }
-
-            //SEE positive: [241, 249]
-            //SEE neutral: 240
-            //SEE negative: [181-189]
-            const bool useSEE = 1;
-            if(useSEE) {
-                PIECE_TYPE capturedType = move.CapturedType();
-                if(capturedType) {
-                    int see = board.SEE(move);
-
-                    if(see > 0) {
-                        int score = ((see - 1) * 8 / 1024) + 241;
-                        score = std::min(score, 249);
-                        assert(score >= 241 && score <= 249);
-                        move.SetScore(SafeCastU8(score)); continue;
-                    }
-                    else if(see == 0) {
-                        move.SetScore(240); continue;
-                    }
-                    else if(see < 0) {
-                        int score = ((see + 1) * 8 / 1024) + 189;
-                        score = std::max(score, 181);
-                        assert(score >= 181 && score <= 189);
-                        move.SetScore(SafeCastU8(score)); continue;
-                    }
-                    
-                }
-            }
-            else {
-                //Captured piece: 200-236
-                PIECE_TYPE capturedType = move.CapturedType();
-                PIECE_TYPE pieceType = move.PieceType();
-                if(capturedType) {
-                    int score = 200 + 6*capturedType - pieceType; //200 + capturedType
-                    assert(score >= 200 && score <= 236);
-                    move.SetScore(SafeCastU8(score));
+                else {
+                    move.SetScore(Scorer::UNDERPROMOTION);
                     continue;
                 }
             }
 
-            //Killer heuristics: 190-194
-            if(move == killer1) {
-                move.SetScore(194);
-                continue;
-            }
-            if(move == killer2) {
-                move.SetScore(193);
-                continue;
-            }
-            if(move == killer3) {
-                move.SetScore(192);
-                continue;
-            }
-            if(move == killer4) {
-                move.SetScore(191);
+            // Captures
+            if( move.CapturedType() ) {
+                int see = board.SEE(move);
+                move.SetScore( Scorer::ScoreFromSEE(see) );
                 continue;
             }
 
-            //History heuristics (1-180)
-            int historyScore = heuristics.history.Get(move, board.ActivePlayer());
-            int maxValue = heuristics.history.MaxValue();
-            const int maxScore = 180;
-            const int minScore = 1;
-            historyScore = minScore + historyScore * (maxScore-minScore) / (maxValue+1);
-            assert(historyScore >= minScore && historyScore <= maxScore);
-            move.SetScore(SafeCastU8(historyScore));
+            //Killer heuristics
+            if(move == killer1) {
+                move.SetScore(Scorer::KILLER_1);
+                continue;
+            }
+            if(move == killer2) {
+                move.SetScore(Scorer::KILLER_2);
+                continue;
+            }
+            if(move == killer3) {
+                move.SetScore(Scorer::KILLER_3);
+                continue;
+            }
+            if(move == killer4) {
+                move.SetScore(Scorer::KILLER_4);
+                continue;
+            }
+
+            // History heuristics
+            int historyValue = heuristics.history.Get(move, board.ActivePlayer());
+            int historyMax = heuristics.history.MaxValue();
+            move.SetScore( Scorer::ScoreFromHistory(historyValue, historyMax) );
 
         }
     }
 
     void RateTactical(Board &board, MoveList &moves) {
-        const int TACTICAL_PROMOTION_CAPTURE_SCORE = 255;
-        const int TACTICAL_PROMOTION_NORMAL_SCORE = 254;
-
         for(auto& move : moves) {
             if(move.MoveType() == PROMOTION_CAPTURE) {
-                move.SetScore(TACTICAL_PROMOTION_CAPTURE_SCORE);
+                move.SetScore(Scorer::TACTICAL_PROMOTION_CAPTURE);
             } else if(move.MoveType() == PROMOTION) {
-                move.SetScore(TACTICAL_PROMOTION_NORMAL_SCORE);
-            } else if(move.MoveType() == CAPTURE || move.MoveType() == ENPASSANT) { // includes enpassant
+                move.SetScore(Scorer::TACTICAL_PROMOTION_NORMAL);
+            } else if( move.CapturedType() ) {
                 int see = board.SEE(move);
-                move.SetScore( SEE::ToScore(see) );
+                move.SetScore( Scorer::TacticalScoreFromSEE(see) );
             }
         }
     }
@@ -137,25 +99,12 @@ namespace {
         // Captures > Other moves
         for(auto& move : moves) {
             if(move.CapturedType())
-                move.SetScore(1);
+                move.SetScore(Scorer::EVASION_CAPTURE);
             else
-                move.SetScore(0);
+                move.SetScore(Scorer::EVASION_NORMAL);
         }
     }
 
-    [[maybe_unused]] bool MVV(const Move &lmove, const Move &rmove) {
-        return lmove.CapturedType() > rmove.CapturedType();
-    }
-    [[maybe_unused]] bool MVVtoLVA(const Move &lmove, const Move &rmove) {
-        if(lmove.CapturedType() > rmove.CapturedType()) //MVV
-            return true;
-
-        else if(lmove.CapturedType() == rmove.CapturedType()) {
-            return lmove.PieceType() < rmove.PieceType(); //LVA
-        }
-
-        return false;
-    }
     bool ByScore(const Move &lmove, const Move &rmove) {
         const u8 lscore = lmove.Score();
         const u8 rscore = rmove.Score();
@@ -169,30 +118,6 @@ namespace {
     }
 
 } //unnamed namespace
-
-// Converts a 'tactical move' score to a 'see' value
-int SEE::FromScore(u8 score) {
-    assert(score >= MIN_SCORE && score <= MAX_SCORE);
-
-    int score_offset = score - MIN_SCORE;
-    int normalized_see = score_offset * SEE_RANGE / SCORE_RANGE;
-
-    int see = normalized_see - SEE_MAX;
-
-    assert(see >= -SEE_MAX && see <= SEE_MAX);
-    return see;
-}
-
-// Converts a 'see' value from board.SEE() to a 'tactical move' score
-u8 SEE::ToScore(int see) {
-    int normalized_see = std::clamp(see, -SEE_MAX, SEE_MAX);
-    normalized_see += SEE_MAX; // Range: (0, SEE_RANGE)
-
-    int score = MIN_SCORE + normalized_see * SCORE_RANGE / SEE_RANGE;
-
-    assert(score >= MIN_SCORE && score <= MAX_SCORE);
-    return SafeCastU8(score);
-}
 
 void Sorting::SortMoves(Board &board, MoveList& moves, TT& tt, const Heuristics &heuristics, int ply) {
     RateMoves(board, moves, tt, heuristics, ply);

--- a/src/MoveScorer.cpp
+++ b/src/MoveScorer.cpp
@@ -1,0 +1,64 @@
+#include "MoveScorer.h"
+
+#include <algorithm>
+
+namespace Scorer {
+    constexpr int SEE_MAX = SEE::MATERIAL_VALUES[QUEEN];
+    constexpr int SEE_RANGE = SEE_MAX * 2;
+
+    constexpr int TACTICAL_RANGE = TACTICAL_MAX - TACTICAL_MIN;
+    constexpr int TACTICAL_NEUTRALCAPTURE = (TACTICAL_MIN + TACTICAL_MAX) / 2; // Equivalent to SEE = 0 for tactical scores
+}
+
+u8 Scorer::ScoreFromHistory(int historyValue, int historyMax) {   
+    int historyScore = HISTORY_MIN + historyValue * (HISTORY_MAX-HISTORY_MIN) / (historyMax+1);
+    
+    assert(historyScore >= HISTORY_MIN && historyScore <= HISTORY_MAX);
+    return SafeCastU8(historyScore);
+}
+
+u8 Scorer::ScoreFromSEE(int see) {
+    if(see > 0) {
+        constexpr int SCORE_RANGE = POSITIVECAPTURE_MAX - POSITIVECAPTURE_MIN;
+
+        int normalized_see = std::clamp(see, 0, SEE_MAX);
+        int score = POSITIVECAPTURE_MIN + normalized_see * SCORE_RANGE / SEE_MAX;
+        
+        assert(score >= POSITIVECAPTURE_MIN && score <= POSITIVECAPTURE_MAX);
+        return SafeCastU8(score);
+    }
+    else if(see == 0) {
+        return NEUTRALCAPTURE;
+    }
+    else { // see < 0
+        constexpr int SCORE_RANGE = NEGATIVECAPTURE_MAX - NEGATIVECAPTURE_MIN;
+
+        int normalized_see = std::clamp(see, -SEE_MAX, 0);
+        int score = NEGATIVECAPTURE_MAX + normalized_see * SCORE_RANGE / SEE_MAX;
+        
+        assert(score >= NEGATIVECAPTURE_MIN && score <= NEGATIVECAPTURE_MAX);
+        return SafeCastU8(score);
+    }
+}
+
+// Converts a 'see' value to a 'tactical move' score
+u8 Scorer::TacticalScoreFromSEE(int see) {
+    int normalized_see = std::clamp(see, -SEE_MAX, SEE_MAX) + SEE_MAX;
+    int score = TACTICAL_MIN + normalized_see * TACTICAL_RANGE / SEE_RANGE;
+
+    assert(score >= TACTICAL_MIN && score <= TACTICAL_MAX);
+    return SafeCastU8(score);
+}
+
+// Converts a 'tactical move' score to a 'see' value
+int Scorer::SEEFromTacticalScore(u8 score) {
+    assert(score >= TACTICAL_MIN && score <= TACTICAL_MAX);
+
+    int score_offset = score - TACTICAL_MIN;
+    int normalized_see = score_offset * SEE_RANGE / TACTICAL_RANGE;
+
+    int see = normalized_see - SEE_MAX;
+
+    assert(see >= -SEE_MAX && see <= SEE_MAX);
+    return see;
+}

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -37,7 +37,7 @@
 
 #include "Evaluation.h"
 #include "MoveGenerator.h"
-#include "NNUE.h" //JUST FOR THE PV
+#include "MoveScorer.h"
 #include "Syzygy.h"
 #include "Uci.h"
 using namespace Sorting;
@@ -757,7 +757,7 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
     for(auto move : moves) {
 
         if(!inCheck && move.MoveType() == CAPTURE) {
-            const int seeValue = SEE::FromScore(move.Score());
+            const int seeValue = Scorer::SEEFromTacticalScore( move.Score() );
 
             // --- Static SEE Pruning ---
             // Quick filter to discard tactically hopeless captures


### PR DESCRIPTION
New **Scorer** namespace to manage all move score calculations.

```
Bench: 1840678 (unchanged)

Elo   | 0.86 +- 9.45 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=16MB
LLR   | 3.04 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 2822 W: 968 L: 961 D: 893
Penta | [112, 316, 545, 329, 109]
```