### PR TITLE
enhance: history with dumped update

### DIFF
--- a/include/Heuristics.h
+++ b/include/Heuristics.h
@@ -3,12 +3,15 @@
 #include "Move.h"
 #include "MoveGenerator.h"
 
+#include <bit>
+
 class Board;
 class TT;
 struct Heuristics;
 
 const int HEURISTICS_MAX_PLY = 128;
-const int VALUE_TO_RESET_HISTORY = INFINITE / 512;
+const int MAX_BONUS = 400;
+constexpr int MAX_HISTORY_VALUE = std::bit_floor( (uint)INFINITE / MAX_BONUS );
 
 namespace Sorting {
     void SortMoves(Board &board, MoveList &moves, TT& tt, const Heuristics &heuristics, int ply);
@@ -63,12 +66,10 @@ public:
         m_maxValue = 0;
     }
     void GoodHistory(const Move& move, COLOR color, int depth) {
-        m_history[color][move.FromSq()][move.ToSq()] += depth*depth;
-        TestOverflow(move, color);
-    }
-    void BadHistory(const Move& move, COLOR color, int depth) {
-        m_history[color][move.FromSq()][move.ToSq()] -= depth*depth;
-        TestOverflow(move, color);
+        int& historyValue = m_history[color][move.FromSq()][move.ToSq()];
+        int bonus = Bonus(depth);
+        historyValue += bonus - (bonus * historyValue) / MAX_HISTORY_VALUE; // Dumped update
+        UpdateMaxValue(historyValue);
     }
     int Get(const Move& move, COLOR color) const {
         return m_history[color][move.FromSq()][move.ToSq()];
@@ -77,18 +78,17 @@ public:
         return m_maxValue;
     }
 private:
-    void TestOverflow(const Move& move, COLOR activeColor) {
-        int value = m_history[activeColor][move.FromSq()][move.ToSq()];
-        if(value > m_maxValue) {
-            m_maxValue = value;
-        }
-        if(m_maxValue > VALUE_TO_RESET_HISTORY) {
-            LoopHistoryTable(m_history[color][from][to] /= 16);
-            m_maxValue /= 16;
+    int Bonus(int depth) const {
+        int bonus = depth * depth;
+        return std::min(MAX_BONUS, bonus);
+    }
+    void UpdateMaxValue(int historyValue) {
+        if(historyValue > m_maxValue) {
+            m_maxValue = historyValue;
         }
     }
 
-    int m_history[2][64][64]; //[COLOR][SQUARE][SQUARE]
+    int m_history[2][64][64]; //[COLOR][SQUARE_FROM][SQUARE_TO]
     int m_maxValue;
 };
 

--- a/include/MoveScorer.h
+++ b/include/MoveScorer.h
@@ -22,7 +22,7 @@ namespace Scorer {
     constexpr int HISTORY_MAX = 180;
     constexpr int HISTORY_MIN = 1;
     constexpr int UNDERPROMOTION = 0;
-    u8 ScoreFromHistory(int historyValue, int historyMax);
+    u8 ScoreFromHistory(int minScore, int maxScore, int historyValue, int historyMax);
     u8 ScoreFromSEE(int see);
 
     // Tactical positions

--- a/src/Heuristics.cpp
+++ b/src/Heuristics.cpp
@@ -77,8 +77,8 @@ namespace {
             // History heuristics
             int historyValue = heuristics.history.Get(move, board.ActivePlayer());
             int historyMax = heuristics.history.MaxValue();
-            move.SetScore( Scorer::ScoreFromHistory(historyValue, historyMax) );
-
+            int score = Scorer::ScoreFromHistory(Scorer::HISTORY_MIN, Scorer::HISTORY_MAX, historyValue, historyMax);
+            move.SetScore(score);
         }
     }
 

--- a/src/MoveScorer.cpp
+++ b/src/MoveScorer.cpp
@@ -10,10 +10,13 @@ namespace Scorer {
     constexpr int TACTICAL_NEUTRALCAPTURE = (TACTICAL_MIN + TACTICAL_MAX) / 2; // Equivalent to SEE = 0 for tactical scores
 }
 
-u8 Scorer::ScoreFromHistory(int historyValue, int historyMax) {   
-    int historyScore = HISTORY_MIN + historyValue * (HISTORY_MAX-HISTORY_MIN) / (historyMax+1);
-    
-    assert(historyScore >= HISTORY_MIN && historyScore <= HISTORY_MAX);
+u8 Scorer::ScoreFromHistory(int minScore, int maxScore, int historyValue, int historyMax) {   
+    int scoreRange = maxScore - minScore;
+    int denominator = historyMax ? historyMax : 1;
+
+    int historyScore = minScore + historyValue * scoreRange / denominator;
+
+    assert(historyScore >= minScore && historyScore <= maxScore);
     return SafeCastU8(historyScore);
 }
 

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -887,7 +887,7 @@ int Search::LateMoveReductions(int moveScore, int depth, int moveNumber, bool is
     const int MULT_FACTOR = 100; 
 
     // History moves
-    if(moveScore < 180) {
+    if(moveScore <= Scorer::HISTORY_MAX) {
         lmr_value = -50 - 200*(isPV)
             + (
                 - (20 * logScore)


### PR DESCRIPTION
**Simplify history heuristics** by using a _dumped_ update:
`historyValue += bonus - (bonus * historyValue) / MAX_HISTORY_VALUE`

In addition:
- Limit the bonus to 400 max. to avoid crazy values at high depths.
- Fix the ScoreFromHistory() method so that it returns values in the whole score range.

```
Bench: 1840089 (previous: 1840678)

Elo   | 8.58 +- 14.42 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1256 W: 433 L: 402 D: 421
Penta | [54, 119, 252, 148, 55]
```