### PR TITLE
fix: segfault in bench command (windows-2025)

### DIFF
--- a/include/NNUE.h
+++ b/include/NNUE.h
@@ -35,9 +35,9 @@ private:
 
     //Current state
     Bitboard* m_pieces[2];
-    float     m_accumulator[2][NNUE_SIZE];
+    alignas(32) float m_accumulator[2][NNUE_SIZE];
     //Backups
-    float     m_backupAccumulator[MAX_PLY_HISTORY][2][NNUE_SIZE];
+    alignas(32) float m_backupAccumulator[MAX_PLY_HISTORY][2][NNUE_SIZE];
 
     bool m_isLoaded;
     std::string m_filepath;
@@ -61,7 +61,7 @@ constexpr uint ARCH_DIMENSIONS[NNUE_LAYERS][PARAMETER_TYPES] = {
     {ARCH[L4][ROW] * ARCH[L4][COL], ARCH[L4][COL]},
 };
 
-struct Network {
+struct alignas(32) Network {
     float w1[ ARCH_DIMENSIONS[L1][W] ];
     float b1[ ARCH_DIMENSIONS[L1][B] ];
     float w2[ ARCH_DIMENSIONS[L2][W] ];

--- a/src/NNUE.cpp
+++ b/src/NNUE.cpp
@@ -93,7 +93,7 @@ Utils::Clock clock_eval;
 
 int NNUE::Evaluate(int color) {
     //Layer 1
-    float o1[ ARCH[L2][ROW] ];
+    alignas(32) float o1[ ARCH[L2][ROW] ];
     for(uint i = 0; i < NNUE_SIZE; i++) {
         o1[i            ] = Clamp(m_accumulator[color][i]);
     }
@@ -102,8 +102,8 @@ int NNUE::Evaluate(int color) {
     }
 
     //Layers 2,3,4
-    float o2[ ARCH[L3][ROW] ];
-    float o3[ ARCH[L4][ROW] ];
+    alignas(32) float o2[ ARCH[L3][ROW] ];
+    alignas(32) float o3[ ARCH[L4][ROW] ];
     float o4[1];
 
     ComputeLayer(o1, o2, m_network.b2, m_network.w2, ARCH[L2][ROW], ARCH[L2][COL], true);


### PR DESCRIPTION
**Fixes**:  segfault in "bench" execution under windows-2025 (MinGW, GCC 15.2)

**Description**: align NNUE floats in memory

```
Bench 1840089 (previous: 1840089)

Elo   | 1.20 +- 9.81 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 2602 W: 862 L: 853 D: 887
Penta | [103, 287, 509, 302, 100]
```