### PR TITLE
fix: segfault in bench command (windows-2025)

### DIFF
--- a/include/Search.h
+++ b/include/Search.h
@@ -20,11 +20,11 @@ struct Limits {
     int nodes = 0;
     int moveTime = 0;
 
-    int wtime;
-    int btime;
+    int wtime = 0;
+    int btime = 0;
 
-    int winc;
-    int binc;
+    int winc = 0;
+    int binc = 0;
 
     int movesToGo = 0;
 };
@@ -44,7 +44,7 @@ public:
 
     // Limits management
     Limits GetLimits() { return m_limits; }
-    void AllocateLimits(Board &board, Limits limits);
+    void AllocateLimits(Board &board, const Limits& limits);
     void FixDepth(int depth);
     void FixTime(int time); // (ms)
     void FixNodes(int nodes);

--- a/src/Evaluation.cpp
+++ b/src/Evaluation.cpp
@@ -139,11 +139,11 @@ void Evaluation::Init() {
     for(int square = 0; square < 64; square++) {
         PASSED_PAWN_FRONT[WHITE][square] = Attacks::GetRay(NORTH, square);
         PASSED_PAWN_FRONT[BLACK][square] = Attacks::GetRay(SOUTH, square);
-        if(Rank(square) == Rank(square+1)) {
+        if(File(square) != FILEH) {
             PASSED_PAWN_SIDES[WHITE][square] |= Attacks::GetRay(NORTH, square+1);
             PASSED_PAWN_SIDES[BLACK][square] |= Attacks::GetRay(SOUTH, square+1);
         }
-        if(Rank(square) == Rank(square-1)) {
+        if(File(square) != FILEA) {
             PASSED_PAWN_SIDES[WHITE][square] |= Attacks::GetRay(NORTH, square-1);
             PASSED_PAWN_SIDES[BLACK][square] |= Attacks::GetRay(SOUTH, square-1);
         }

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -828,7 +828,7 @@ bool Search::TimeOver() {
 // - depth: search for a fixed depth
 // - moveTime: search for a fixed time
 // - nodes: search for a fixed number of nodes
-void Search::AllocateLimits(Board &board, Limits limits) {
+void Search::AllocateLimits(Board &board, const Limits& limits) {
     m_limits = limits;
     m_nodes = 0;
     m_clock.Start();
@@ -846,7 +846,7 @@ void Search::AllocateLimits(Board &board, Limits limits) {
     if(limits.nodes)    { FixNodes(limits.nodes); return; }
     
     // Time estimation in normal games
-    limits.movesToGo = 20 + 20 * limits.ponderhit;
+    const int movesToGo = 20 + 20 * limits.ponderhit;
 
     COLOR color = board.ActivePlayer();
 
@@ -855,7 +855,7 @@ void Search::AllocateLimits(Board &board, Limits limits) {
 
     int myInc    = (color == WHITE) ? limits.winc  : limits.binc;
 
-    m_allocatedTime = myTime / limits.movesToGo + myInc;
+    m_allocatedTime = myTime / movesToGo + myInc;
 
     if(m_debugMode)
         std::cout << "info string TimeAllocation " <<  myTime << " " << yourTime << " " << m_allocatedTime << std::endl;

--- a/src/Uci.cpp
+++ b/src/Uci.cpp
@@ -156,7 +156,7 @@ void Uci::Bench(int depth, bool verbose) {
         "6r1/1ppnr1kp/pq1b1p2/2p1pPP1/P3P3/1P1P1N2/R1PB3Q/5R1K b - - 2 30", // RG10 - Midgame Closed
         "8/5p2/2B2k2/p7/1pr5/4r3/P1P3P1/3R2K1 w - - 12 48", // RG4 - Ending
         "r3qb1k/1b4p1/p2pr2p/3n4/Pnp1N1N1/6RP/1B3PP1/1B1QR1K1 w - - 0 1", // Nolot 1 - Wide tree
-        "rnbq1b1r/p1pp1p1p/4k3/1p1NP1p1/2QP1p2/5N2/PP1B1KPP/n6R/ w - -", // Albillo 11 - Checks and mates
+        "rnbq1b1r/p1pp1p1p/4k3/1p1NP1p1/2QP1p2/5N2/PP1B1KPP/n6R w - - 0 1", // Albillo 11 - Checks and mates
         "8/3P4/n2K2kp/2p3nN/1b6/2p1p1P1/8/3B4 w - - 4 3",  // Quiescence and deep pruning
         "8/4RNpk/p7/r1pr4/5P2/2P3K1/b2R4/8 w - - 1 40", // Lichess study - Search extensions 1
         "8/p7/2k1p3/5p1p/2KP1P1P/P7/8/8 b - - 0 37", // Lichess study - Pawn Endgame 1


### PR DESCRIPTION
**Fix**:
* Segfault in "bench" execution under **windows-2025** (MinGW, GCC 15.2).
#49 did not solve it. Passing _Limits_ object by reference does.

**Secondary fixes**:
* Prevent possible OOB in Evaluation init.
* Malformed FEN in benchmark positions.

```
Bench 1840089 (previous: 1840089)

Elo   | 32.00 +- 23.61 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 490 W: 180 L: 135 D: 175
Penta | [16, 43, 95, 62, 29]
```