### PR TITLE
chore: version 1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 project(Casanchess 
-    VERSION 0.9.0
+    VERSION 1.0.0
     LANGUAGES CXX
 )
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Carlos Sánchez Mayordomo
+Copyright (c) 2026 Carlos Sánchez Mayordomo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Uci.cpp
+++ b/src/Uci.cpp
@@ -17,8 +17,8 @@
 namespace {
     const std::string ENGINE_NAME = "Casanchess";
     const std::string AUTHOR = "Carlos Sanchez Mayordomo";
-    const std::string VERSION_MAJOR = "0";
-    const std::string VERSION_MINOR = "9";
+    const std::string VERSION_MAJOR = "1";
+    const std::string VERSION_MINOR = "0";
     const std::string VERSION_PATCH = "0";
 }
 


### PR DESCRIPTION
#  **Version 1.0.0**

### ✨ Features
* **[Improvement]** Added Syzygy Tablebases support (Probe_WDL) and related UCI commands (#38).
* **[Improvement]** Added an Evaluation Cache (2MB) to the quiescence search (qsearch) storing 16-bit partial zkeys (#21, #43).
* **[Improvement]** Added Principal Variation Search (PVS) to root moves (RootMax) (#30).
* **[Improvement]** New futility pruning algorithm for quiet moves in negamax (#31).

### 📈 Enhancements
* **[Improvement]** New neural network `network-20260712.nnue` trained on 578M positions (#55, #56, #57).
* **[Improvement]** Extreme move generation optimization (stateless, stack memory), significantly improving kN/s (#25).
* **[Improvement]** Tuned futility pruning parameters to `0 + depth * 25` (#35).
* **[Improvement]** Implemented an asymmetrical and incremental aspiration window (#37).
* **[Improvement]** TT now returns EXACT bound scores for non-PV nodes (#41).
* **[No-Regression]** qsearch improvements: conservative delta pruning for neutral captures and static SEE pruning (#22).
* **[No-Regression]** PV array is now properly reported in UCI using triangle arrays instead of TT (#39).
* **[No-Regression]** Simplified history heuristics (dumped update) and limited the maximum bonus (#45).

### 🐛 Bugfixes
* **[Improvement]** Fixed PV node definition in the search tree, allowing for more aggressive pruning (#27, #28).
* **[No-Regression]** Added `!isPV` condition to Null-Move Pruning to never cutoff PV nodes (#32).
* **[No-Regression]** Fixed segfault errors in the `bench` command under Windows/MinGW (#49, #50).
* **[No-Regression]** Fixed Zobrist Key mismatches when comparing FEN vs MakeMove in en-passant captures (#26).

### 🛠️ Refactor
* **[No-Regression]** Cleaned up and improved Transposition Table (Hash) initialization (#34).
* **[No-Regression]** Created `Scorer` namespace to manage move score calculations (#44).
* Refactored MoveGenerator to include a `BitboardIterator` for better readability (#24).
* Migrated all codebase to use `#pragma once` instead of include guards (#29).

### 📝 Documentation & Chore
* Openbench alignment: Non-verbose bench command, default depth increased to 9, and locked to 1 thread (#33, #36).
* Added unit tests and header documentation (#48).

---

The first major release introduces support for **Syzygy Tablebases**, a **stronger neural network**, and several **search improvements**, resulting in a higher playing strength.

**Features**
* Syzygy Tablebases: Add WDL support. Configurable via new UCI commands `SyzygyPath` and `SyzygyProbeLimit`.
* Evaluation Cache: Introduce a fast evaluation cache for quiescence search, notably improving performance at ultra-short time controls.

**Enhancements**
* New Neural Network: `network-20260712.nnue`, trained on ~570M evaluations (12% of them random positions), providing a strength increase of ~50 ELO.
* Search & Pruning: Implement Principal Variation Search (PVS) for root moves, asymmetrical incremental aspiration windows, and a newly tuned, more aggressive futility pruning algorithm.
* Stateless Move Generation: Optimize move generation to use stack memory instead of heap, increasing the engine's speed.
* TT Improvements: The Transposition Table now returns EXACT bound scores for non-PV nodes, maximizing the use of high-quality search information.
* History Heuristics: Simplify history updates to avoid extreme value distortions at very high depths.

**Bugfixes**
* Fix: Incorrect Principal Variation (PV) node definition throughout the search tree. Fixing this unlocked more aggressive pruning in non-PV nodes.
* Fix: Avoid Null-Move Pruning in PV nodes.
* Fix: Segfault crashes when executing the `bench` command on Windows compilers.
* Fix: High number of tablebase hits breaking the UCI PV report (now solved by using triangle arrays).
* Fix: Zobrist Key mismatches involving en-passant squares when starting from FEN positions.

**Consistency & Stability**
* Aligned `bench` command and UCI options (like `Threads` locked to 1 for tests) with OpenBench standards.
* Added comprehensive unit tests and improved engine documentation.

Full Changelog: v0.9...v1.0

---

```
Benchmark: 2262281

7s+0.07s / 4553 - 1442 - 2005  [0.694] 8000
Elo difference: 142.6 +/- 6.9, DrawRatio: 25.1 %

30+0.3s / 1552 - 556 - 892  [0.666] 3000
Elo difference: 119.9 +/- 10.7, LOS: 100.0 %, DrawRatio: 29.7 %
```
