### PR TITLE
fix: prevent TT/PV corruption on timeout and fix node counting

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -155,8 +155,7 @@ void Search::IterativeDeepening(Board &board, bool fullClear) {
         AspirationWindow(board, m_depth, m_bestScore);
 
         // Stop search if limits are reached within the loop
-        if(m_stop)
-            break;
+        if(m_stop) break;
 
         // Update counters
         m_elapsedTime = ElapsedTime();
@@ -233,7 +232,7 @@ int Search::AspirationWindow(Board& board, const int depth, const int bestScore)
 
     int score = RootMax(board, depth, alpha, beta);
 
-    for(int researches = 1; (score <= alpha || score >= beta); researches++) {
+    for(int researches = 1; !m_stop && (score <= alpha || score >= beta); researches++) {
         D( m_debug.Increment("AspirationWindow: Out of bounds: Researches: " + std::to_string(researches) ); );
 
         // Asymmetrical incremental aspiration
@@ -312,6 +311,8 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
         board.TakeMove(move);
         m_ply--;
 
+        if(m_stop) break;
+
         if(score > alpha) {
             D( m_debug.Increment("RootMax: AlphaBeta: Update: BestMove (score > alpha)") );
             alpha = score;
@@ -323,11 +324,6 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
         // Not useful to store in TT due to aspiration window
         if(score >= beta) {
             D( m_debug.Increment("RootMax: AlphaBeta: Beta Cutoff (score >= beta)") );
-            break;
-        }
-
-        if(m_stop || TimeOver()) {
-            m_stop = true;
             break;
         }
     }
@@ -625,6 +621,8 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
         board.TakeMove(move);
         m_ply--;
 
+        if(m_stop) return 0;
+
         if(score > bestScore) {
             D( m_debug.Increment("NegaMax: AlphaBeta: Update: BestMove") );
             bestScore = score;
@@ -675,6 +673,13 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
 
     D( m_debug.Increment("Quiescence: _: Hits"); );
     D( if(m_plyqs <= 2 || m_plyqs % 5 == 0) m_debug.Increment("Quiescence: QPly " + std::format("{:03}", m_plyqs)) );
+
+    // Termination checks
+    m_nodesTimeCheck++;
+    if( m_stop || NodeLimit() || TimeOver() ) {
+        m_stop = true;
+        return 0;
+    }
 
     // Prevent infinite recursion in rare cases (unlikely to occur)
     if (m_plyqs >= MAX_QS_PLIES) {
@@ -790,6 +795,8 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
         
         board.TakeMove(move);
         m_ply--; m_plyqs--;
+
+        if(m_stop) return 0;
 
         D( BoardIdentity aft = BoardIntegrityChecker::GenerateBoardIdentity(board); );
         D( assert(bef == aft) );

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -262,6 +262,8 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
 
     D( m_debug.Increment("RootMax: _: Hit") );
 
+    m_nodes++;
+
     Move bestMove;
     int score;
 
@@ -293,7 +295,7 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
         }
 
         board.MakeMove(move);
-        m_ply++; m_nodes++;
+        m_ply++;
 
         // -------- Principal Variation Search (PVS) -----------
         // PV move: full window
@@ -349,11 +351,13 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
 
     D( m_debug.Increment("NegaMax: _: Entering function") );
 
+    m_nodes++;
+    m_nodesTimeCheck++;
+
     const bool isPV = (beta - alpha) != 1;
     m_pv.ClearPly(m_ply);
 
     // --------- Termination checks -----------
-    m_nodesTimeCheck++;
     if( m_stop || NodeLimit() || TimeOver() ) {
         m_stop = true;
         return 0;
@@ -596,7 +600,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
         }
 
         board.MakeMove(move);
-        m_ply++; m_nodes++;
+        m_ply++;
 
         // -------- Principal Variation Search (PVS) -----------
         int fullDepth = depth - 1 + extension + localExtension;
@@ -674,8 +678,10 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
     D( m_debug.Increment("Quiescence: _: Hits"); );
     D( if(m_plyqs <= 2 || m_plyqs % 5 == 0) m_debug.Increment("Quiescence: QPly " + std::format("{:03}", m_plyqs)) );
 
-    // Termination checks
+    m_nodes++;
     m_nodesTimeCheck++;
+
+    // Termination checks
     if( m_stop || NodeLimit() || TimeOver() ) {
         m_stop = true;
         return 0;
@@ -788,7 +794,7 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
 
         board.MakeMove(move);
 
-        m_ply++; m_plyqs++; m_nodes++; m_selPly = std::max(m_selPly, m_ply);
+        m_ply++; m_plyqs++; m_selPly = std::max(m_selPly, m_ply);
         D( m_debug.Increment("Quiescence: MakeMove (QPly > 0)") );
 
         int score = -QuiescenceSearch(board, -beta, -alpha);


### PR DESCRIPTION
Fixes a bug where hitting a time/node limit during the search corrupted the Transposition Table and Principal Variation with incomplete evaluations. It also corrects the node counting behavior.

**Fix:**
* **Search corruption on timeout:** Added immediate stack unwinding (`if(m_stop) return 0`) after `TakeMove` in all search functions. This prevents incomplete/garbage scores from polluting `alpha`, `bestMove`, and the TT.
* **Potential time forfeits in Quiescence Search:** Added termination checks (`TimeOver()` and `NodeLimit()`) at the beginning of `QuiescenceSearch`. This prevents timeouts during QS explosions and correctly obeys `go nodes X` UCI commands.

**Non-functional:**
* **Accurate Node Counting:** Relocated `m_nodes++` to the very beginning of the search functions. Node counts now accurately reflect TT hits, root nodes, and QS stand-pat cutoffs, raising the reported NPS.


```
bench: 3950388 --> new way to count nodes!!

Elo   | 7.61 +- 13.83 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1370 W: 482 L: 452 D: 436
Penta | [58, 133, 278, 153, 63]
```