### PR TITLE
fix: use bestScore for TT bound evaluation instead of alpha + simplify delta pruning

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -658,7 +658,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
 
     // Store score in transposition table
     if(bestMove.MoveType() != 0) {
-        bool alphaWithinBounds = (alpha > alphaOriginal);
+        bool alphaWithinBounds = (bestScore > alphaOriginal);
         alphaWithinBounds ? D( m_debug.Increment("NegaMax: AlphaBeta: Exact") )
                           : D( m_debug.Increment("NegaMax: AlphaBeta: UpperBound") );
         TTENTRY_TYPE type = alphaWithinBounds ? TTENTRY_TYPE::EXACT

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -783,11 +783,8 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
                 estimatedScore = standPat + DELTA_MARGIN_RISKY + seeValue;
             }
 
-            if(estimatedScore < alpha) {
-                if(estimatedScore > bestScore)
-                    bestScore = estimatedScore;
+            if(estimatedScore < alpha)
                 continue;
-            }
         }
         
         D( BoardIdentity bef = BoardIntegrityChecker::GenerateBoardIdentity(board); );


### PR DESCRIPTION
Fix:
* Correct TT bound evaluation in negamax.
Now uses `bestScore > alphaOriginal` to determine if a bound is EXACT or UPPER_BOUND. This prevents storing false EXACT entries when alpha is artificially raised (e.g. Mate Distance Pruning).
* Prevent `bestScore` updates with unreal values in QS delta pruning.
When the condition `estimatedScore < alpha` was triggered, `bestScore = estimatedScore` was assigned. This was too conservative. Eliminating this reduces the search tree in some positions.

```
bench 3258009 (previous 3950388)

Elo   | 2.74 +- 10.75 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 2152 W: 745 L: 728 D: 679
Penta | [82, 234, 432, 241, 87]

Elo   | 10.84 +- 14.30 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 994 W: 326 L: 295 D: 373
Penta | [22, 105, 220, 120, 30]
```