### PR TITLE
fix: refactor SEE to fix X-Ray blind spots

### DIFF
--- a/include/Board.h
+++ b/include/Board.h
@@ -53,7 +53,7 @@ public:
     void TakeNull() { MoveMaker::TakeNull(*this); }
 
     // Static Exchange Evaluation
-    int SEE(Move move);
+    int SEE(Move move) const;
 
     // Helper methods
     Bitboard AttackersTo(COLOR color, int square, Bitboard blockers) const;
@@ -66,7 +66,6 @@ public:
     bool IsRepetitionDraw(int searchPly = 0);
     void Mirror();
     int SquareToIndex(std::string square) const;
-    Bitboard XRayAttackersTo(COLOR color, int square);
 
     //Getters
     inline COLOR ActivePlayer() const       { return m_activePlayer; }
@@ -91,7 +90,7 @@ private:
     void InitStateAndHistory();
 
     //Static Exchange Evaluation
-    Bitboard LeastValuableAttacker(Bitboard attackers, COLOR color, PIECE_TYPE& pieceType);
+    Bitboard LeastValuableAttacker(Bitboard attackers, COLOR color, PIECE_TYPE& pieceType) const;
 
     //State
     COLOR m_activePlayer;

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -148,68 +148,64 @@ void Board::ShowMoves() {
 // Simulates all recaptures on the target square using least valuable attacker first.
 //
 // Example: White Pawn takes Black Knight, Black Pawn recaptures
-//   scores[0] = +300 (knight value)
-//   scores[1] = 100 - 300 = -200 (pawn value minus previous)
-//   Negamax: scores[0] = +200 (net: knight gained, pawn lost)
+//   gain[0] = 300 (Black Knight captured by White)
+//   gain[1] = 100 (White Pawn captured by Black)
 //
-// Returns: Material gain/loss in centipawns (positive = good for side to move)
-int Board::SEE(Move move) {
-    COLOR color = ActivePlayer();
-    COLOR enemyColor = InactivePlayer();
+//   Minimax evaluation (bottom-up):
+//   depth 1: gain[0] -= max(0, gain[1]) -> 300 - max(0, 100) = 200
+//   Result: +200 (Net: Knight gained, Pawn lost).
+int Board::SEE(Move move) const {
     MoveData moveData = move.Data();
 
-    //List of scores to be filled
-    const int MAX_CAPTURES = 24;
-    int scores[MAX_CAPTURES];
-    int numCapture = 0;
+    // Array to store the captured piece value at each depth
+    int gain[32];
+    int depth = 0;
 
-    //Direct attackers to the square
-    Bitboard attackers = XRayAttackersTo(color, moveData.toSq) | XRayAttackersTo(enemyColor, moveData.toSq);
+    // Piece value of the captured piece
+    gain[0] = SEE::MATERIAL_VALUES[moveData.capturedType];
 
-    //Initial capture
-    attackers ^= SquareBB(moveData.fromSq);
-    scores[numCapture] = SEE::MATERIAL_VALUES[moveData.capturedType];
-    int pieceValue = SEE::MATERIAL_VALUES[moveData.pieceType]; //what is actually on the square
-
-    // switch the active player
-    color = (COLOR)!color;
-    enemyColor = (COLOR)!enemyColor;
-
-    //the main loop, where all the captures are simulated
-    while(attackers) {
-        Bitboard activeAttackers = attackers & Piece(color, ALL_PIECES);
-        if(!activeAttackers) break;
-
-        //get the Least Valuable Attacker
-        PIECE_TYPE pieceType = NO_PIECE;
-        Bitboard LVA = LeastValuableAttacker(activeAttackers, color, pieceType);
-        attackers ^= LVA;
-
-        //if king... do smth
-
-        //fill an array of scores / current-piece-on-square
-        numCapture++;
-        assert(numCapture <= MAX_CAPTURES);
-        scores[numCapture] = pieceValue - scores[numCapture-1];
-        pieceValue = SEE::MATERIAL_VALUES[pieceType];
-
-        // switch the active player
-        color = (COLOR)!color;
-        enemyColor = (COLOR)!enemyColor;
-    }
-
-    // add hidden pieces
-    //another options is to check for bishops, rooks and queen in the moving direction?? (don't do for kings and knights)
-
-    //retrieve best score
-    while(numCapture > 0) {
-        if(scores[numCapture] > -scores[numCapture-1]) { //scores[numCapture-1] > -scores[numCapture]
-            scores[numCapture-1] = -scores[numCapture];
+    // Our piece that captures
+    PIECE_TYPE attackingPiece = moveData.pieceType;
+    if(move.IsPromotion()) {
+        switch(move.PromotionType()) {
+            case PROMOTION_QUEEN:  attackingPiece = QUEEN;  break;
+            case PROMOTION_KNIGHT: attackingPiece = KNIGHT; break;
+            case PROMOTION_ROOK:   attackingPiece = ROOK;   break;
+            case PROMOTION_BISHOP: attackingPiece = BISHOP; break;
         }
-        numCapture--;
     }
 
-    return scores[0];
+    // Remove the attacker from the original square
+    Bitboard occupied = m_allpieces ^ SquareBB(moveData.fromSq);
+    COLOR sideToMove = InactivePlayer();
+
+    // Keep iterating until there are no more attackers on the target square
+    while(true) {
+        Bitboard attackers = AttackersTo((COLOR)!sideToMove, moveData.toSq, occupied) & occupied;
+
+        if(!attackers) break;
+
+        PIECE_TYPE lvaPiece;
+        Bitboard lvaBitboard = LeastValuableAttacker(attackers, sideToMove, lvaPiece);
+
+        gain[depth + 1] = SEE::MATERIAL_VALUES[attackingPiece];
+
+        // New piece at target square
+        attackingPiece = lvaPiece;
+
+        // Remove the LVA from the original square
+        occupied ^= lvaBitboard;
+        sideToMove = (COLOR)!sideToMove;
+
+        depth++;
+    }
+
+    // Evaluate sequence from depth to 0, negamax style
+    for(int i = depth; i > 0; i--) {
+        gain[i - 1] -= std::max(0, gain[i]); // Don't capture if the gain is negative
+    }
+
+    return gain[0];
 }
 
 //Attackers
@@ -365,35 +361,7 @@ int Board::SquareToIndex(std::string square) const {
     return index;
 }
 
-Bitboard Board::XRayAttackersTo(COLOR color, int square) {
-    Bitboard attackers = ZERO;
-
-    COLOR enemyColor = (COLOR)!color;
-
-    //Non-sliding
-    Bitboard pawnAttackers = AttacksPawns(color, square) & Piece(enemyColor, PAWN);
-    attackers |= pawnAttackers;
-    attackers |= AttacksKnights(square) & Piece(enemyColor, KNIGHT);
-    attackers |= AttacksKing(square) & Piece(enemyColor, KING);
-
-    //Eliminate enemy king for sliding calculation
-    Bitboard blockers = m_allpieces ^ Piece(color, KING); //will be attacked after check
-
-    //Bishop
-    pawnAttackers |= AttacksPawns(enemyColor, square) & Piece(color, PAWN); //add all pawns (TEST!)
-    Bitboard diagonalPieces = Piece(enemyColor, BISHOP) | Piece(enemyColor, QUEEN);
-    Bitboard diagonalBlockers = blockers ^ (pawnAttackers | diagonalPieces);
-    attackers |= AttacksSliding(BISHOP, square, diagonalBlockers) & diagonalPieces;
-
-    //Rook
-    Bitboard straightPieces = Piece(enemyColor, ROOK) | Piece(enemyColor, QUEEN);
-    Bitboard straightBlockers = blockers ^ straightPieces;
-    attackers |= AttacksSliding(ROOK, square, straightBlockers) & straightPieces;
-
-    return attackers;
-}
-
-Bitboard Board::LeastValuableAttacker(Bitboard attackers, COLOR color, PIECE_TYPE& pieceType) {
+Bitboard Board::LeastValuableAttacker(Bitboard attackers, COLOR color, PIECE_TYPE& pieceType) const {
     assert(attackers);
     for(PIECE_TYPE ipiece = PAWN; ipiece <= KING; ++ipiece) {
         Bitboard pieceAttackers = attackers & Piece(color, ipiece);

--- a/tests/test-Board.cpp
+++ b/tests/test-Board.cpp
@@ -56,6 +56,20 @@ TEST(SEE, QueenTakesDefendedPawn) {
     EXPECT_EQ(board.SEE(move), -950);
 }
 
+// Bishop and pawn aligned. Pawn captures knight, bishop x-ray behind pawn.
+//       p
+//     n
+//   P
+// B
+TEST(SEE, XRayBlockedByPawn) {
+    Board board;
+    board.SetFen("3k4/8/4p3/3n4/2P5/1B6/8/3K4 w - - 0 1");
+    
+    Move move(C4, D5, PAWN, CAPTURE);
+    move.SetCapturedType(KNIGHT);
+    EXPECT_EQ(board.SEE(move), 350);
+}
+
 // ==========
 // == Board ==
 // ==========


### PR DESCRIPTION
Rewrite the **Static Exchange Evaluation (SEE)** function to use a dynamic occupancy bitboard. This fixes bugs in X-Ray detection and adds promotion handling, while reducing code complexity.

**Fixes**:
* **X-Ray Attack Detection:** Fix a blind spot where sliding pieces hidden behind a same-color piece were completely ignored. By removing the captured pieces from a dynamic `occupied` bitboard at each step, X-Ray attackers are now naturally "discovered" by the `AttackersTo` function.

**Functional:**
* **Promotion Handling:** `SEE` now accurately updates the value of the attacking piece if the move is a promotion. Previously, a pawn capturing and promoting to a Queen would be incorrectly valued as a pawn in subsequent recaptures.

**Non-functional:**
* **Rewritten SEE**: Remove the complex `XRayAttackersTo` pre-calculation entirely; the main loop now simulates the physics of the board by toggling bits off an `occupied` bitboard.
The minimax is more elegant now, using a clean negamax-style loop using a simple array (`gain[i - 1] -= std::max(0, gain[i])`).
* **New Unit Test:** Add `SEE.XRayBlockedByPawn` to guarantee batteries blocked by pawns or knights are correctly evaluated without regressions.

```
bench 3161934 (previous 3258009)

Elo   | 0.11 +- 9.16 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 3130 W: 1091 L: 1090 D: 949
Penta | [147, 310, 637, 337, 134]

Elo   | -1.43 +- 7.15 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 4376 W: 1389 L: 1407 D: 1580
Penta | [139, 506, 917, 486, 140]
```