### PR TITLE
enhance: repetition draw

### DIFF
--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -323,7 +323,7 @@ bool Board::IsRepetitionDraw(int searchPly) {
         if(ZKey() == m_history[m_ply - i].zkey) rep++;
 
         // 2-repetitions are enough within the search
-        if(rep == 2 && searchPly > i) return true;
+        if(rep == 2 && searchPly >= i) return true;
 
         // 3-repetitions are needed in real game
         if(rep == 3) return true;

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -313,16 +313,21 @@ bool Board::IsCheckAnyColor() {
 }
 
 bool Board::IsRepetitionDraw(int searchPly) {
-    int rep = 0;
+    int rep = 1;
 
-    int imax = std::max(searchPly, (int)m_fiftyrule);
-    int ply = m_ply - m_initialPly;
+    int imax = (int)m_fiftyrule; // Logical limit
+    int ply = m_ply - m_initialPly; // Physical limit
 
     int i = 4;
     while(i <= imax && i <= ply) {
         if(ZKey() == m_history[m_ply - i].zkey) rep++;
-        if(rep == 1 && searchPly > i) return true;
-        if(rep == 2) return true;
+
+        // 2-repetitions are enough within the search
+        if(rep == 2 && searchPly > i) return true;
+
+        // 3-repetitions are needed in real game
+        if(rep == 3) return true;
+
         i += 2;
     }
     return false;


### PR DESCRIPTION
Modify the **Repetition Draw detection** function to:
* Strictly respect the fifty-move rule limit
* Detect earlier the 2-fold root repetition within search

These changes slightly improve the search performance.

```
bench 3200745 (previous: 3161934)

Elo   | 4.73 +- 13.72 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.05 (-2.94, 2.94) [-18.00, 0.00]
Games | N: 1322 W: 463 L: 445 D: 414
Penta | [55, 123, 288, 139, 56]

Elo   | 8.93 +- 14.09 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1206 W: 397 L: 366 D: 443
Penta | [39, 132, 236, 151, 45]
```