### PR TITLE
enhance: remove stalemate from QS

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -740,17 +740,10 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
     MoveList moves = inCheck ? MoveGenerator::GenerateEvasionMoves(board)
                              : MoveGenerator::GenerateTacticalMoves(board);
 
-    // Checkmate or stalemate
-    if( moves.empty() ) {
-        if(inCheck) {
-            D( m_debug.Increment("Quiescence: EmptyMoves: Checkmate") );
-            return -MATESCORE_MAX + m_ply; // Checkmate
-        }
-        // Generate all the moves to verify stalemate
-        else if( MoveGenerator::GenerateMoves(board).size() == 0 ) {
-            D( m_debug.Increment("Quiescence: EmptyMoves: Stalemate") );
-            return DRAW_SCORE(m_ply); // Stalemate
-        }
+    // Checkmate (ignore stalemate)
+    if( moves.empty() && inCheck ) {
+        D( m_debug.Increment("Quiescence: EmptyMoves: Checkmate") );
+        return -MATESCORE_MAX + m_ply;
     }
 
     // Different move ordering for efficiency


### PR DESCRIPTION
Optimize the Quiescence Search (QS) by **removing the stalemate check** when no tactical moves are available. This eliminates a heavy performance bottleneck in leaf nodes.

Stalemate is an extremely rare event at the QS stage. There is no need to generate all moves (expensive function) to check for stalemate, when the main search can deal with it.

```
bench 3161934

Elo   | 12.41 +- 16.33 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1008 W: 365 L: 329 D: 314
Penta | [40, 98, 206, 106, 54]

Elo   | 2.90 +- 10.55 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 2036 W: 648 L: 631 D: 757
Penta | [70, 214, 426, 245, 63]
```