### PR TITLE
enhance: SEE promotion recaptures and enpassant

### DIFF
--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -200,6 +200,11 @@ int Board::SEE(Move move) const {
         // New piece at target square
         attackingPiece = lvaPiece;
 
+        // Promotions during recapture
+        if (attackingPiece == PAWN && (Rank(moveData.toSq) == RANK1 || Rank(moveData.toSq) == RANK8)) {
+            attackingPiece = QUEEN;
+        }
+
         // Remove the LVA from the original square
         occupied ^= lvaBitboard;
         sideToMove = (COLOR)!sideToMove;

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -179,6 +179,13 @@ int Board::SEE(Move move) const {
     Bitboard occupied = m_allpieces ^ SquareBB(moveData.fromSq);
     COLOR sideToMove = InactivePlayer();
 
+    // Enpassant special case
+    if(moveData.moveType == ENPASSANT) {
+        int capturedPawnSq = moveData.toSq + (ActivePlayer() == WHITE ? -8 : 8);
+        // Move the attacker pawn to the target square and remove the captured pawn
+        occupied ^= (SquareBB(moveData.toSq) | SquareBB(capturedPawnSq));
+    }
+
     // Keep iterating until there are no more attackers on the target square
     while(true) {
         Bitboard attackers = AttackersTo((COLOR)!sideToMove, moveData.toSq, occupied) & occupied;

--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -373,6 +373,7 @@ namespace {
 
                 if(toBitboard) {
                     Move move = Move(fromSq, toSq, PAWN, MOVE_TYPE::ENPASSANT);
+                    move.SetCapturedType(PAWN);
                     context.AddMove(move);
                 }
             }

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -752,7 +752,7 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
 
     for(auto move : moves) {
 
-        if(!inCheck && move.MoveType() == CAPTURE) {
+        if(!inCheck && move.IsCapture() && !move.IsPromotion()) {
             const int seeValue = Scorer::SEEFromTacticalScore( move.Score() );
 
             // --- Static SEE Pruning ---

--- a/tests/test-Board.cpp
+++ b/tests/test-Board.cpp
@@ -70,6 +70,16 @@ TEST(SEE, XRayBlockedByPawn) {
     EXPECT_EQ(board.SEE(move), 350);
 }
 
+// Enpassant
+TEST(SEE, EnPassant) {
+    Board board;
+    board.SetFen("3n3k/8/8/3Pp3/8/8/8/K3R3 w - e6 0 1");
+    
+    Move move(D5, E6, PAWN, ENPASSANT);
+    move.SetCapturedType(PAWN);
+    EXPECT_EQ(board.SEE(move), 100);
+}
+
 // ==========
 // == Board ==
 // ==========

--- a/tests/test-Board.cpp
+++ b/tests/test-Board.cpp
@@ -70,7 +70,6 @@ TEST(SEE, XRayBlockedByPawn) {
     EXPECT_EQ(board.SEE(move), 350);
 }
 
-// Enpassant
 TEST(SEE, EnPassant) {
     Board board;
     board.SetFen("3n3k/8/8/3Pp3/8/8/8/K3R3 w - e6 0 1");
@@ -78,6 +77,20 @@ TEST(SEE, EnPassant) {
     Move move(D5, E6, PAWN, ENPASSANT);
     move.SetCapturedType(PAWN);
     EXPECT_EQ(board.SEE(move), 100);
+}
+
+TEST(SEE, PromotionInRecapture) {
+    Board board;
+    board.SetFen("3rk3/2P2n2/4N3/8/8/8/8/K7 w - - 0 1");
+    
+    Move move(E6, D8, KNIGHT, CAPTURE);
+    move.SetCapturedType(ROOK);
+
+    // If promotions in recapture were not handled, the engine would think that
+    // after Nxd8 Nxd8, the pawn on c7 could recepture favorably (+400).
+    // With the promotion handled correctly, recapturing with the pawn loses
+    // a Queen and the engine aborts the sequence earlier (rook vs knight, +150).
+    EXPECT_EQ(board.SEE(move), 150);
 }
 
 // ==========


### PR DESCRIPTION
Add **promotion recaptures and enpassant** to the **Static Exchange Evaluation (SEE)**.

```
bench 3200746 (previous: 3200745)
```