### PR TITLE
enhance: SEE promotions and enpassant

### DIFF
--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -147,6 +147,8 @@ void Board::ShowMoves() {
 // Evaluates a capture sequence to determine if it wins or loses material.
 // Simulates all recaptures on the target square using least valuable attacker first.
 //
+// It works as well for normal moves, en-passant and promotions.
+//
 // Example: White Pawn takes Black Knight, Black Pawn recaptures
 //   gain[0] = 300 (Black Knight captured by White)
 //   gain[1] = 100 (White Pawn captured by Black)
@@ -182,7 +184,7 @@ int Board::SEE(Move move) const {
     Bitboard occupied = m_allpieces ^ SquareBB(moveData.fromSq);
     COLOR sideToMove = InactivePlayer();
 
-    // Enpassant special case
+    // Special case: en-passant
     if(moveData.moveType == ENPASSANT) {
         int capturedPawnSq = moveData.toSq + (ActivePlayer() == WHITE ? -8 : 8);
         // Move the attacker pawn to the target square and remove the captured pawn

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -193,6 +193,11 @@ int Board::SEE(Move move) const {
         // New piece at target square
         attackingPiece = lvaPiece;
 
+        // Promotions during recapture
+        if (attackingPiece == PAWN && (Rank(moveData.toSq) == RANK1 || Rank(moveData.toSq) == RANK8)) {
+            attackingPiece = QUEEN;
+        }
+
         // Remove the LVA from the original square
         occupied ^= lvaBitboard;
         sideToMove = (COLOR)!sideToMove;

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -182,6 +182,13 @@ int Board::SEE(Move move) const {
     Bitboard occupied = m_allpieces ^ SquareBB(moveData.fromSq);
     COLOR sideToMove = InactivePlayer();
 
+    // Enpassant special case
+    if(moveData.moveType == ENPASSANT) {
+        int capturedPawnSq = moveData.toSq + (ActivePlayer() == WHITE ? -8 : 8);
+        // Move the attacker pawn to the target square and remove the captured pawn
+        occupied ^= (SquareBB(moveData.toSq) | SquareBB(capturedPawnSq));
+    }
+
     // Keep iterating until there are no more attackers on the target square
     while(true) {
         Bitboard attackers = AttackersTo((COLOR)!sideToMove, moveData.toSq, occupied) & occupied;

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -166,6 +166,8 @@ int Board::SEE(Move move) const {
 
     // Our piece that captures
     PIECE_TYPE attackingPiece = moveData.pieceType;
+
+    // Special case: promotions
     if(move.IsPromotion()) {
         switch(move.PromotionType()) {
             case PROMOTION_QUEEN:  attackingPiece = QUEEN;  break;
@@ -173,6 +175,7 @@ int Board::SEE(Move move) const {
             case PROMOTION_ROOK:   attackingPiece = ROOK;   break;
             case PROMOTION_BISHOP: attackingPiece = BISHOP; break;
         }
+        gain[0] += SEE::MATERIAL_VALUES[attackingPiece] - SEE::MATERIAL_VALUES[PAWN];
     }
 
     // Remove the attacker from the original square
@@ -196,6 +199,7 @@ int Board::SEE(Move move) const {
         // Promotions during recapture
         if (attackingPiece == PAWN && (Rank(moveData.toSq) == RANK1 || Rank(moveData.toSq) == RANK8)) {
             attackingPiece = QUEEN;
+            gain[depth + 1] += SEE::MATERIAL_VALUES[QUEEN] - SEE::MATERIAL_VALUES[PAWN];
         }
 
         // Remove the LVA from the original square

--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -373,6 +373,7 @@ namespace {
 
                 if(toBitboard) {
                     Move move = Move(fromSq, toSq, PAWN, MOVE_TYPE::ENPASSANT);
+                    move.SetCapturedType(PAWN);
                     context.AddMove(move);
                 }
             }

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -752,7 +752,7 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
 
     for(auto move : moves) {
 
-        if(!inCheck && move.MoveType() == CAPTURE) {
+        if(!inCheck && move.IsCapture() && !move.IsPromotion()) {
             const int seeValue = Scorer::SEEFromTacticalScore( move.Score() );
 
             // --- Static SEE Pruning ---

--- a/tests/test-Board.cpp
+++ b/tests/test-Board.cpp
@@ -70,6 +70,15 @@ TEST(SEE, XRayBlockedByPawn) {
     EXPECT_EQ(board.SEE(move), 350);
 }
 
+TEST(SEE, EnPassant) {
+    Board board;
+    board.SetFen("3n3k/8/8/3Pp3/8/8/8/K3R3 w - e6 0 1");
+    
+    Move move(D5, E6, PAWN, ENPASSANT);
+    move.SetCapturedType(PAWN);
+    EXPECT_EQ(board.SEE(move), 100);
+}
+
 TEST(SEE, PromotionRecapture_EarlyStop) {
     Board board;
     board.SetFen("3r4/2P2n2/4Nk2/8/8/8/8/K7 w - - 0 1");

--- a/tests/test-Board.cpp
+++ b/tests/test-Board.cpp
@@ -70,6 +70,34 @@ TEST(SEE, XRayBlockedByPawn) {
     EXPECT_EQ(board.SEE(move), 350);
 }
 
+TEST(SEE, PromotionRecapture_EarlyStop) {
+    Board board;
+    board.SetFen("3r4/2P2n2/4Nk2/8/8/8/8/K7 w - - 0 1");
+    
+    Move move(E6, D8, KNIGHT, CAPTURE);
+    move.SetCapturedType(ROOK);
+
+    // The SEE algorithm will see that after Nxd8 Nxd8, the pawn on c7 can recapture
+    // and promote to a queen (unfavourable for black).
+    // Therefore, black does not take the attacking piece.
+    // (net gain for white: +rook).
+    EXPECT_EQ(board.SEE(move), 500);
+}
+
+TEST(SEE, PromotionRecapture_FullSequence) {
+    Board board;
+    board.SetFen("Q2r4/2P2n2/5k2/b7/8/8/8/K7 w - - 0 1");
+    
+    Move move(A8, D8, QUEEN, CAPTURE);
+    move.SetCapturedType(ROOK);
+
+    // The SEE algorithm will see that after Qxd8 Nxd8, the pawn on c7 can recapture
+    // and promote to a queen. But this time recapturing is favourable for black.
+    // Therefore, black takes the attacking piece.
+    // (net gain for white: +rook -queen +knight +(queen-pawn) -queen).
+    EXPECT_EQ(board.SEE(move), -300);
+}
+
 // ==========
 // == Board ==
 // ==========


### PR DESCRIPTION
Add **promotion recaptures** and **enpassant** to the **Static Exchange Evaluation (SEE)**.

```
bench 3484044 (previous: 3200745)

Elo   | 2.94 +- 10.62 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.21 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 2246 W: 780 L: 761 D: 705
Penta | [96, 222, 464, 249, 92]

Elo   | 4.35 +- 11.42 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1758 W: 569 L: 547 D: 642
Penta | [58, 188, 367, 206, 60]
```