### PR TITLE
simplify: remove QS static SEE pruning

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -754,14 +754,6 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
 
         if(!inCheck && move.IsCapture() && !move.IsPromotion()) {
             const int seeValue = Scorer::SEEFromTacticalScore( move.Score() );
-
-            // --- Static SEE Pruning ---
-            // Quick filter to discard tactically hopeless captures
-            const int SEE_PRUNING_THRESHOLD = -250;
-            if(seeValue < SEE_PRUNING_THRESHOLD) {
-                D( m_debug.Increment("Quiescence: Pruning: SEE << 0") );
-                continue;
-            }
             
             // --- Delta Pruning ---
             // Calculate a heuristic score for futility pruning. Depending on the SEE:


### PR DESCRIPTION
Remove **static SEE pruning** in Quiescence Search (QS).

```
bench 3484044

Elo   | 7.48 +- 13.77 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1394 W: 485 L: 455 D: 454
Penta | [52, 151, 282, 139, 73]

Elo   | -2.69 +- 5.89 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 6582 W: 2069 L: 2120 D: 2393
Penta | [206, 804, 1338, 721, 222]
```