### PR TITLE
enhance: move TT probing before standPat in QS

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -693,12 +693,25 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
         return Evaluation::Evaluate(board);
     }
 
+    // Probe transposition table.
+    // Only non-PV nodes: PV nodes require the most accurate score possible.
+    TTEntry* ttEntry = Hash::tt.Probe(board.ZKey(), 0);
     const bool isPV = (beta - alpha) != 1;
-    int bestScore = -INFINITE_SCORE;
-    bool inCheck = board.IsCheck();
+    if(ttEntry && !isPV) {
+        int score = Hash::tt.ScoreFromHash(ttEntry->score, m_ply);
+        if( ttEntry->type == TTENTRY_TYPE::EXACT
+            || (ttEntry->type == TTENTRY_TYPE::UPPER_BOUND && score <= alpha)
+            || (ttEntry->type == TTENTRY_TYPE::LOWER_BOUND && score >= beta)
+        ) {
+            D( m_debug.Increment("Quiescence: TT Hit") );
+            return score;
+        }
+    }
 
     // Stand pat: static evaluation of current position
     int standPat = 0;
+    int bestScore = -INFINITE_SCORE;
+    bool inCheck = board.IsCheck();
     if(!inCheck) {
         // Probe evaluation cache first (modifies standPat if hit)
         const bool cacheHit = Hash::evalCache.Probe(board.ZKey(), standPat);
@@ -718,20 +731,6 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
             alpha = standPat;
         }
         bestScore =  standPat;
-    }
-
-    // Probe transposition table.
-    // Only non-PV nodes: PV nodes require the most accurate score possible.
-    TTEntry* ttEntry = Hash::tt.Probe(board.ZKey(), 0);
-    if(ttEntry && !isPV) {
-        int score = Hash::tt.ScoreFromHash(ttEntry->score, m_ply);
-        if( ttEntry->type == TTENTRY_TYPE::EXACT
-            || (ttEntry->type == TTENTRY_TYPE::UPPER_BOUND && score <= alpha)
-            || (ttEntry->type == TTENTRY_TYPE::LOWER_BOUND && score >= beta)
-        ) {
-            D( m_debug.Increment("Quiescence: TT Hit") );
-            return score;
-        }
     }
 
     // Generate captures.


### PR DESCRIPTION
Probe the TT before calling the evaluation function for stand-pat in Quiescence Search (QS).

Saves calls to the Evaluation function.

```
bench 2855713 (previous: 3484044)

Elo   | 6.55 +- 6.42 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [-2.00, 8.00]
Games | N: 6418 W: 2262 L: 2141 D: 2015
Penta | [261, 676, 1261, 703, 308]

Elo   | 11.86 +- 9.25 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [-2.00, 8.00]
Games | N: 2490 W: 827 L: 742 D: 921
Penta | [61, 263, 534, 304, 83]
```