### PR TITLE
simplify: QS pruning

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -759,22 +759,23 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
 
         if(!inCheck && move.IsCapture() && !move.IsPromotion()) {
             const int seeValue = Scorer::SEEFromTacticalScore( move.Score() );
+
+            // Prune negative SEE captures
+            if(seeValue < 0) {
+                D( m_debug.Increment("Quiescence: Pruning SEE < 0") );
+                continue;
+            }
             
             // --- Delta Pruning ---
-            // Calculate a heuristic score for futility pruning. Depending on the SEE:
-            //  - For safe captures (SEE >= 0): an optimistic score using the maximum potential gain to represent the move impact.
-            //  - For sacrifices    (SEE  < 0): a realistic estimate using the material cost to determine if the sacrifice is affordable.
-            int estimatedScore;
-            if(seeValue >= 0) {
-                const int DELTA_MARGIN_SAFE = 90;
-                estimatedScore = standPat + DELTA_MARGIN_SAFE + SEE::MATERIAL_VALUES[move.CapturedType()];
-            } else {
-                const int DELTA_MARGIN_RISKY = 0;
-                estimatedScore = standPat + DELTA_MARGIN_RISKY + seeValue;
-            }
+            // For SEE >= 0 captures
+            // Use an optimistic score using the maximum potential gain to represent the move impact.
+            const int DELTA_MARGIN_SAFE = 90;
+            int estimatedScore = standPat + DELTA_MARGIN_SAFE + SEE::MATERIAL_VALUES[move.CapturedType()];
 
-            if(estimatedScore < alpha)
+            if(estimatedScore < alpha) {
+                D( m_debug.Increment("Quiescence: Pruning SEE >= 0: estimatedScore < alpha") );
                 continue;
+            }
         }
         
         D( BoardIdentity bef = BoardIntegrityChecker::GenerateBoardIdentity(board); );


### PR DESCRIPTION
Simpler prune of **negative SEE captures** in QS.

Eliminate the variable `DELTA_MARGIN_RISKY`.

```
bench 2855713

Elo   | -2.13 +- 8.40 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.08 (-2.94, 2.94) [-18.00, 0.00]
Games | N: 3424 W: 1151 L: 1172 D: 1101
Penta | [130, 380, 714, 357, 131]

Elo   | -5.07 +- 9.20 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 3.02 (-2.94, 2.94) [-25.00, 0.00]
Games | N: 2740 W: 862 L: 902 D: 976
Penta | [106, 305, 562, 317, 80]
```