### PR TITLE
interface: update counters in UCI live updates

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -285,13 +285,19 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
         if(DEBUG_SEARCH_TREE)
             P( "RootMax: " << move.Notation() );
 
-        if(UCI_OUTPUT) {
-            //Uci output: show the root move number under analysis
-            if(m_elapsedTime > UCI_OUTPUT_CURRMOVE_MINTIME) {
-                std::cout << "info currmovenumber " << moveNumber;
-                std::cout << " currmove " << move.Notation();
-                std::cout << std::endl;
-            }
+        if(UCI_OUTPUT && m_elapsedTime > UCI_OUTPUT_CURRMOVE_MINTIME) {
+            // UCI: show the root move under analysis and update the counters
+            m_elapsedTime = ElapsedTime();
+            m_nps = static_cast<int>(1000 * m_nodes / (m_elapsedTime+1));
+
+            std::cout << "info depth " << m_depth
+                      << " currmovenumber " << moveNumber
+                      << " currmove " << move.Notation()
+                      << " time " << m_elapsedTime
+                      << " nodes " << m_nodes
+                      << " nps " << m_nps
+                      << " tbhits " << m_tbHits
+                      << std::endl;
         }
 
         board.MakeMove(move);


### PR DESCRIPTION
Update counters (**time, nodes, nps, tbhits**) after each root move in UCI output.

Previously, only the `currmove` and `currmovenumber` were displayed (after 1 second of searching).

```
bench 2855713

Elo   | -0.30 +- 10.51 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [-18.00, 0.00]
Games | N: 2326 W: 792 L: 794 D: 740
Penta | [96, 259, 456, 255, 97]

Elo   | 27.85 +- 44.41 (95%)
Conf  | 60.0+0.60s Threads=1 Hash=16MB
Games | N: 100 W: 34 L: 26 D: 40
Penta | [0, 13, 19, 15, 3]
```