### PR TITLE
enhance: RootMax fail-soft

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -345,6 +345,13 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
         D( m_debug.Increment("RootMax: AlphaBeta: Exact") );
         Hash::tt.Store(board.ZKey(), bestScore, TTENTRY_TYPE::EXACT, bestMove, depth, m_ply, m_searchCount);
     }
+    else if(!m_stop && bestMove.MoveType() != 0) {
+        bool failLow = (bestScore <= alphaOriginal);
+        D( m_debug.Increment("RootMax: AlphaBeta: " + std::string(failLow ? "UpperBound" : "LowerBound")) );
+        TTENTRY_TYPE type = failLow ? TTENTRY_TYPE::UPPER_BOUND
+                                    : TTENTRY_TYPE::LOWER_BOUND;
+        Hash::tt.Store(board.ZKey(), bestScore, type, bestMove, depth, m_ply, m_searchCount);
+    }
 
     return bestScore;
 }

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -322,17 +322,17 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
             bestMove = move;
         }
 
+        // Not useful to store in TT due to aspiration window
+        if(score >= beta) {
+            D( m_debug.Increment("RootMax: AlphaBeta: Beta Cutoff (score >= beta)") );
+            break;
+        }
+
         if(score > alpha) {
             D( m_debug.Increment("RootMax: AlphaBeta: Update Alpha (score > alpha)") );
             alpha = score;
 
             m_pv.Update(m_ply, move, score);
-        }
-
-        // Not useful to store in TT due to aspiration window
-        if(score >= beta) {
-            D( m_debug.Increment("RootMax: AlphaBeta: Beta Cutoff (score >= beta)") );
-            break;
         }
     }
 

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -265,10 +265,11 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
     m_nodes++;
 
     Move bestMove;
-    int score;
-
-    m_pv.ClearPly(m_ply);
+    int bestScore = -INFINITE_SCORE;
     int alphaOriginal = alpha; // Save the original alpha for TT logic
+    int score;
+    
+    m_pv.ClearPly(m_ply);
 
     MoveList moves = MoveGenerator::GenerateMoves(board);
 
@@ -315,10 +316,15 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
 
         if(m_stop) break;
 
-        if(score > alpha) {
-            D( m_debug.Increment("RootMax: AlphaBeta: Update: BestMove (score > alpha)") );
-            alpha = score;
+        if(score > bestScore) {
+            D( m_debug.Increment("RootMax: AlphaBeta: Update BestMove (score > bestScore)") );
+            bestScore = score;
             bestMove = move;
+        }
+
+        if(score > alpha) {
+            D( m_debug.Increment("RootMax: AlphaBeta: Update Alpha (score > alpha)") );
+            alpha = score;
 
             m_pv.Update(m_ply, move, score);
         }
@@ -331,16 +337,16 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
     }
 
     // Store "exact" score in transposition table if search finished within search bounds
-    bool outOfLimits = alpha <= alphaOriginal || alpha >= beta;
-    if(!m_stop && !outOfLimits) {
+    bool withinBounds = (bestScore > alphaOriginal) && (bestScore < beta);
+    if(!m_stop && withinBounds) {
         m_bestMove = bestMove;
-        m_bestScore = alpha;
+        m_bestScore = bestScore;
 
         D( m_debug.Increment("RootMax: AlphaBeta: Exact") );
-        Hash::tt.Store(board.ZKey(), m_bestScore, TTENTRY_TYPE::EXACT, m_bestMove, depth, m_ply, m_searchCount);
+        Hash::tt.Store(board.ZKey(), bestScore, TTENTRY_TYPE::EXACT, bestMove, depth, m_ply, m_searchCount);
     }
 
-    return alpha;
+    return bestScore;
 }
 
 // Negamax search: core recursive alpha-beta search.
@@ -628,7 +634,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
         if(m_stop) return 0;
 
         if(score > bestScore) {
-            D( m_debug.Increment("NegaMax: AlphaBeta: Update: BestMove") );
+            D( m_debug.Increment("NegaMax: AlphaBeta: Update BestMove") );
             bestScore = score;
             bestMove = move;
         }
@@ -648,7 +654,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
         }
 
         if(score > alpha) {
-            D( m_debug.Increment("NegaMax: AlphaBeta: Update: Alpha") );
+            D( m_debug.Increment("NegaMax: AlphaBeta: Update Alpha") );
             alpha = score;
  
             m_pv.Update(m_ply, move, score);
@@ -658,11 +664,11 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
 
     // Store score in transposition table
     if(bestMove.MoveType() != 0) {
-        bool alphaWithinBounds = (bestScore > alphaOriginal);
-        alphaWithinBounds ? D( m_debug.Increment("NegaMax: AlphaBeta: Exact") )
-                          : D( m_debug.Increment("NegaMax: AlphaBeta: UpperBound") );
-        TTENTRY_TYPE type = alphaWithinBounds ? TTENTRY_TYPE::EXACT
-                                              : TTENTRY_TYPE::UPPER_BOUND;
+        bool withinBounds = (bestScore > alphaOriginal);
+        withinBounds ? D( m_debug.Increment("NegaMax: AlphaBeta: Exact") )
+                     : D( m_debug.Increment("NegaMax: AlphaBeta: UpperBound") );
+        TTENTRY_TYPE type = withinBounds ? TTENTRY_TYPE::EXACT
+                                         : TTENTRY_TYPE::UPPER_BOUND;
         Hash::tt.Store(board.ZKey(), bestScore, type, bestMove, depth, m_ply, m_searchCount);
     }
 


### PR DESCRIPTION
```
bench 

Elo   | 0.11 +- 9.25 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 3116 W: 1061 L: 1060 D: 995
Penta | [144, 335, 582, 370, 127]

Ongoing
```