### PR TITLE
fix: PV array overflow

### DIFF
--- a/include/PV.h
+++ b/include/PV.h
@@ -12,7 +12,7 @@ public:
     void ClearTable();
     void ClearPly(int ply);
 
-    void Update(int ply, Move move, int score);
+    void Update(int ply, Move move);
 
     Move PonderMove() const;
     std::string PVString() const;

--- a/include/PV.h
+++ b/include/PV.h
@@ -18,9 +18,9 @@ public:
     std::string PVString() const;
 
 private:
-    using PVLine = std::array<Move, MAX_PLY>;
-    using PVTable = std::array<PVLine, MAX_PLY>;
+    using PVLine = std::array<Move, MAX_PLY + 1>;
+    using PVTable = std::array<PVLine, MAX_PLY + 1>; // +1 to allow safe read of childPly
 
     PVTable m_pvTable;
-    std::array<int, MAX_PLY> m_pvLength;
+    std::array<int, MAX_PLY + 1> m_pvLength;
 };

--- a/src/PV.cpp
+++ b/src/PV.cpp
@@ -16,7 +16,7 @@ void PV::ClearPly(int ply) {
     m_pvLength[ply] = 0;
 }
 
-void PV::Update(int ply, Move move, [[maybe_unused]] int score) {
+void PV::Update(int ply, Move move) {
     m_pvTable[ply][0] = move;
 
     const int childPly = ply + 1;

--- a/src/PV.cpp
+++ b/src/PV.cpp
@@ -5,14 +5,14 @@ PV::PV() {
 }
 
 void PV::ClearTable() {
-    for(int i = 0; i < MAX_PLY; ++i) {
+    for(int i = 0; i <= MAX_PLY; ++i) {
         ClearPly(i);
     }
 }
 
 // Clear the PV for the current ply
 void PV::ClearPly(int ply) {
-    assert(ply >= 0 && ply < MAX_PLY);
+    assert(ply >= 0 && ply <= MAX_PLY);
     m_pvLength[ply] = 0;
 }
 

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -326,7 +326,7 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
             alpha = score;
             bestMove = move;
 
-            m_pv.Update(m_ply, move, score);
+            m_pv.Update(m_ply, move);
         }
 
         // Not useful to store in TT due to aspiration window
@@ -657,7 +657,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
             D( m_debug.Increment("NegaMax: AlphaBeta: Update: Alpha") );
             alpha = score;
  
-            m_pv.Update(m_ply, move, score);
+            m_pv.Update(m_ply, move);
         }
 
     } // End move loop

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -361,7 +361,8 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
     m_nodesTimeCheck++;
 
     const bool isPV = (beta - alpha) != 1;
-    m_pv.ClearPly(m_ply);
+    if(isPV)
+        m_pv.ClearPly(m_ply);
 
     // --------- Termination checks -----------
     if( m_stop || NodeLimit() || TimeOver() ) {


### PR DESCRIPTION
Fix a potential **PV array overflow at MAX_PLY** (unlikely to occur).

Other minor improvements:
- Performance: ClearPly only in PV nodes
- Refactor: eliminate unused variable 'score'

```
bench 2855713

Elo   | 3.05 +- 15.69 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.29 (-2.94, 2.94) [-24.00, 0.00]
Games | N: 1026 W: 348 L: 339 D: 339
Penta | [37, 117, 204, 110, 45]
```