### PR TITLE
enhance: use the hash move in QS

### DIFF
--- a/include/Heuristics.h
+++ b/include/Heuristics.h
@@ -15,8 +15,8 @@ constexpr int MAX_HISTORY_VALUE = std::bit_floor( (uint)INFINITE / MAX_BONUS );
 
 namespace Sorting {
     void SortMoves(Board &board, MoveList &moves, TT& tt, const Heuristics &heuristics, int ply);
-    void SortEvasions(Board &board, MoveList &moves);
-    void SortTactical(Board &board, MoveList &moves);
+    void SortEvasions(Board &board, MoveList &moves, Move hashMove);
+    void SortTactical(Board &board, MoveList &moves, Move hashMove);
 }
 
 class KillerHeuristics {

--- a/include/MoveScorer.h
+++ b/include/MoveScorer.h
@@ -26,9 +26,9 @@ namespace Scorer {
     u8 ScoreFromSEE(int see);
 
     // Tactical positions
-    constexpr int TACTICAL_PROMOTION_CAPTURE = 255;
-    constexpr int TACTICAL_PROMOTION_NORMAL = 254;
-    constexpr int TACTICAL_MAX = 253;
+    constexpr int TACTICAL_PROMOTION_CAPTURE = 254;
+    constexpr int TACTICAL_PROMOTION_NORMAL = 253;
+    constexpr int TACTICAL_MAX = 252;
     constexpr int TACTICAL_MIN = 1;
     u8 TacticalScoreFromSEE(int see);
     int SEEFromTacticalScore(u8 score);

--- a/src/Heuristics.cpp
+++ b/src/Heuristics.cpp
@@ -82,9 +82,12 @@ namespace {
         }
     }
 
-    void RateTactical(Board &board, MoveList &moves) {
+    void RateTactical(Board &board, MoveList &moves, Move hashMove) {
+        // Hash > Promotions > Captures
         for(auto& move : moves) {
-            if(move.MoveType() == PROMOTION_CAPTURE) {
+            if(move == hashMove) {
+                move.SetScore(Scorer::HASH);
+            } else if(move.MoveType() == PROMOTION_CAPTURE) {
                 move.SetScore(Scorer::TACTICAL_PROMOTION_CAPTURE);
             } else if(move.MoveType() == PROMOTION) {
                 move.SetScore(Scorer::TACTICAL_PROMOTION_NORMAL);
@@ -95,13 +98,16 @@ namespace {
         }
     }
 
-    void RateEvasions([[maybe_unused]] Board &board, MoveList &moves) {
-        // Captures > Other moves
+    void RateEvasions([[maybe_unused]] Board &board, MoveList &moves, Move hashMove) {
+        // Hash > Captures > Other moves
         for(auto& move : moves) {
-            if(move.CapturedType())
+            if(move == hashMove) {
+                move.SetScore(Scorer::HASH);
+            } else if(move.CapturedType()) {
                 move.SetScore(Scorer::EVASION_CAPTURE);
-            else
+            } else {
                 move.SetScore(Scorer::EVASION_NORMAL);
+            }
         }
     }
 
@@ -124,12 +130,12 @@ void Sorting::SortMoves(Board &board, MoveList& moves, TT& tt, const Heuristics 
     std::ranges::sort(moves, ByScore);
 }
 
-void Sorting::SortEvasions(Board &board, MoveList& moves) {
-    RateEvasions(board, moves);
+void Sorting::SortEvasions(Board &board, MoveList& moves, Move hashMove) {
+    RateEvasions(board, moves, hashMove);
     std::ranges::sort(moves, ByScore);
 }
 
-void Sorting::SortTactical(Board &board, MoveList& moves) {
-    RateTactical(board, moves);
+void Sorting::SortTactical(Board &board, MoveList& moves, Move hashMove) {
+    RateTactical(board, moves, hashMove);
     std::ranges::sort(moves, ByScore);
 }

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -770,8 +770,9 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
 
     for(auto move : moves) {
 
-        if(!inCheck && move.IsCapture() && !move.IsPromotion() && move != hashMove) {
-            const int seeValue = Scorer::SEEFromTacticalScore( move.Score() );
+        if(!inCheck && move.IsCapture() && !move.IsPromotion()) {
+            const int seeValue = (move == hashMove) ? board.SEE(move)
+                                                    : Scorer::SEEFromTacticalScore( move.Score() );
 
             // Prune negative SEE captures
             if(seeValue < 0) {

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -709,15 +709,21 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
     // Probe transposition table.
     // Only non-PV nodes: PV nodes require the most accurate score possible.
     TTEntry* ttEntry = Hash::tt.Probe(board.ZKey(), 0);
+    Move hashMove; // For move ordering
     const bool isPV = (beta - alpha) != 1;
-    if(ttEntry && !isPV) {
-        int score = Hash::tt.ScoreFromHash(ttEntry->score, m_ply);
-        if( ttEntry->type == TTENTRY_TYPE::EXACT
-            || (ttEntry->type == TTENTRY_TYPE::UPPER_BOUND && score <= alpha)
-            || (ttEntry->type == TTENTRY_TYPE::LOWER_BOUND && score >= beta)
-        ) {
-            D( m_debug.Increment("Quiescence: TT Hit") );
-            return score;
+    if(ttEntry) {
+        D( m_debug.Increment("Quiescence: TT Hit: Exists") );
+        hashMove = ttEntry->bestMove;
+
+        if(!isPV) {
+            int score = Hash::tt.ScoreFromHash(ttEntry->score, m_ply);
+            if( ttEntry->type == TTENTRY_TYPE::EXACT
+                || (ttEntry->type == TTENTRY_TYPE::UPPER_BOUND && score <= alpha)
+                || (ttEntry->type == TTENTRY_TYPE::LOWER_BOUND && score >= beta)
+            ) {
+                D( m_debug.Increment("Quiescence: TT Hit: Return score") );
+                return score;
+            }
         }
     }
 
@@ -759,12 +765,12 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
     }
 
     // Different move ordering for efficiency
-    inCheck ? SortEvasions(board, moves)
-            : SortTactical(board, moves);
+    inCheck ? SortEvasions(board, moves, hashMove)
+            : SortTactical(board, moves, hashMove);
 
     for(auto move : moves) {
 
-        if(!inCheck && move.IsCapture() && !move.IsPromotion()) {
+        if(!inCheck && move.IsCapture() && !move.IsPromotion() && move != hashMove) {
             const int seeValue = Scorer::SEEFromTacticalScore( move.Score() );
 
             // Prune negative SEE captures


### PR DESCRIPTION
Prioritize the **Hash Move** during Quiescence Search (QS) move ordering.

WITHOUT delta-pruning the hash move as the other captures:
```
bench 3487676 (previously 2855713)

Elo   | 5.88 +- 6.51 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [-3.00, 8.00]
Games | N: 6024 W: 2132 L: 2030 D: 1862
Penta | [238, 629, 1198, 687, 260]

FAILED LTC
```

WITH delta-pruning the hash move as the other captures:
```
bench 3510591 (previously 2855713)

Elo   | 5.94 +- 5.97 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [-2.00, 8.00]
Games | N: 7316 W: 2534 L: 2409 D: 2373
Penta | [288, 794, 1413, 831, 332]

Elo   | 9.31 +- 8.12 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-2.00, 8.00]
Games | N: 3508 W: 1169 L: 1075 D: 1264
Penta | [104, 380, 723, 412, 135]
```