### PR TITLE
enhance: update bestMove when found

### DIFF
--- a/include/Hash.h
+++ b/include/Hash.h
@@ -13,8 +13,8 @@ constexpr u64 EVALCACHE_ENTRIES = 1 << 19;
 // == Transposition table ==
 // =========================
 
-// Alpha node: the true eval is at most equal to the score (true <= score) UPPER_BOUND
-// Beta node: the true eval is at least equal to the score (true >= score) LOWER_BOUND
+// Alpha node (from a fail-low): the true eval is at most equal to the score (truth <= score) UPPER_BOUND
+// Beta node (from a fail-high): the true eval is at least equal to the score (truth >= score) LOWER_BOUND
 enum class TTENTRY_TYPE : u8 { NONE, EXACT, LOWER_BOUND, UPPER_BOUND };
 
 // 32(zkey) + 32(move) + 16(score) + 8(depth) + 2(type) + 6(age) + 32(padding) = 128 bits per entry

--- a/include/Search.h
+++ b/include/Search.h
@@ -3,6 +3,7 @@
 #include "Board.h"
 #include "Constants.h"
 #include "Debug.h"
+#include "Hash.h"
 #include "Heuristics.h"
 #include "Move.h"
 #include "PV.h"
@@ -11,6 +12,8 @@
 #include <vector>
 
 const int MAX_ROOTMOVES = 256;
+
+using BOUND_TYPE = TTENTRY_TYPE;
 
 // Search limits from UCI
 struct Limits {
@@ -67,12 +70,13 @@ private:
     int QuiescenceSearch(Board &board, int alpha, int beta);
 
     // IterativeDeepening methods
-    void UciOutput(std::string PV);
+    void UciOutput(std::string PV, int score, BOUND_TYPE bound = BOUND_TYPE::EXACT);
 
     // NegaMax methods
     int LateMoveReductions(int moveScore, int depth, int moveNumber, bool isPV);
 
-    // Limits
+    // Limits and internal calculations
+    int CalculateNPS() { return static_cast<int>(1000 * m_nodes / (m_elapsedTime+1)); }
     bool TimeOver();
     bool NodeLimit() { return m_nodes >= m_forcedNodes; };
 

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -158,13 +158,8 @@ void Search::IterativeDeepening(Board &board, bool fullClear) {
         // Stop search if limits are reached within the loop
         if(m_stop) break;
 
-        // Update counters
-        m_elapsedTime = ElapsedTime();
-        m_nps = static_cast<int>(1000 * m_nodes / (m_elapsedTime+1));
-
         // PV
-        if(UCI_OUTPUT)
-            UciOutput(m_pv.PVString());
+        UciOutput(m_pv.PVString(), m_bestScore);
 
         // Stop search if we used half of the allocated time, since
         // next iteration will likely use more than the allocated time
@@ -183,16 +178,25 @@ void Search::IterativeDeepening(Board &board, bool fullClear) {
     }
 }
 
-void Search::UciOutput(std::string PV) {
+void Search::UciOutput(std::string PV, int score, BOUND_TYPE bound) {
+    if(!UCI_OUTPUT) return;
+
+    m_elapsedTime = ElapsedTime();
+    m_nps = CalculateNPS();
+
     std::cout << "info depth " << m_depth;
     std::cout << " seldepth " << m_selPly;
-    if(IsMateValue(m_bestScore)) {
-        int mateScore = (m_bestScore > 0) ?  MATESCORE_MAX - m_bestScore + 1
-                                          : -MATESCORE_MAX - m_bestScore - 1;
+
+    if(IsMateValue(score)) {
+        int mateScore = (score > 0) ?  MATESCORE_MAX - score + 1
+                                    : -MATESCORE_MAX - score - 1;
         std::cout << " score mate " << mateScore / 2; //return mate in moves, not in plies
     } else {
-        std::cout << " score cp " << m_bestScore;
+        std::cout << " score cp " << score;
     }
+    if(bound == BOUND_TYPE::LOWER_BOUND) std::cout << " lowerbound";
+    if(bound == BOUND_TYPE::UPPER_BOUND) std::cout << " upperbound";
+
     std::cout << " time " << m_elapsedTime;
     std::cout << " nodes " << m_nodes;
     std::cout << " nps " << m_nps;
@@ -235,6 +239,11 @@ int Search::AspirationWindow(Board& board, const int depth, const int bestScore)
 
     for(int researches = 1; !m_stop && (score <= alpha || score >= beta); researches++) {
         D( m_debug.Increment("AspirationWindow: Out of bounds: Researches: " + std::to_string(researches) ); );
+
+        // Display fail-low info
+        if(score <= alpha) {
+            UciOutput(m_pv.PVString(), score, BOUND_TYPE::UPPER_BOUND);
+        }
 
         // Asymmetrical incremental aspiration
         window = window * ASPIRATION_WINDOW_MULTIPLIER;
@@ -287,19 +296,20 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
         if(DEBUG_SEARCH_TREE)
             P( "RootMax: " << move.Notation() );
 
+        // Display the root move under analysis and update the counters
         if(UCI_OUTPUT && m_elapsedTime > UCI_OUTPUT_CURRMOVE_MINTIME) {
-            // UCI: show the root move under analysis and update the counters
             m_elapsedTime = ElapsedTime();
-            m_nps = static_cast<int>(1000 * m_nodes / (m_elapsedTime+1));
+            m_nps = CalculateNPS();
 
             std::cout << "info depth " << m_depth
                       << " currmovenumber " << moveNumber
                       << " currmove " << move.Notation()
                       << " time " << m_elapsedTime
                       << " nodes " << m_nodes
-                      << " nps " << m_nps
-                      << " tbhits " << m_tbHits
-                      << std::endl;
+                      << " nps " << m_nps;
+            if(m_tbHits)
+                std::cout << " tbhits " << m_tbHits;
+            std::cout << std::endl;
         }
 
         board.MakeMove(move);
@@ -340,6 +350,12 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
             alpha = score;
 
             m_pv.Update(m_ply, move);
+
+            if(m_elapsedTime > UCI_OUTPUT_CURRMOVE_MINTIME) {
+                BOUND_TYPE bound = (score >= beta) ? BOUND_TYPE::LOWER_BOUND
+                                                   : BOUND_TYPE::EXACT;
+                UciOutput(m_pv.PVString(), score, bound);
+            }
         }
     }
 

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -345,6 +345,8 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
         // Not useful to store in TT due to aspiration window
         if(score >= beta) {
             D( m_debug.Increment("RootMax: AlphaBeta: Beta Cutoff (score >= beta)") );
+            m_bestMove = move;
+
             break;
         }
 

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -62,7 +62,7 @@ const int NULLMOVE_REDUCTION_FACTOR = 3;
 const bool TURNOFF_LMR = false;
 const bool TURNOFF_FUTILITY = false;
 
-const int UCI_OUTPUT_CURRMOVE_MINTIME = 1000; //ms
+const int UCI_OUTPUT_ROOTMAX_MINTIME = 1000; //ms
 
 // Draw contempt to discourage premature draws
 constexpr int DrawScore(int ply) {
@@ -179,10 +179,10 @@ void Search::IterativeDeepening(Board &board, bool fullClear) {
 }
 
 void Search::UciOutput(std::string PV, int score, BOUND_TYPE bound) {
-    if(!UCI_OUTPUT) return;
-
     m_elapsedTime = ElapsedTime();
     m_nps = CalculateNPS();
+
+    if(!UCI_OUTPUT) return;
 
     std::cout << "info depth " << m_depth;
     std::cout << " seldepth " << m_selPly;
@@ -240,10 +240,10 @@ int Search::AspirationWindow(Board& board, const int depth, const int bestScore)
     for(int researches = 1; !m_stop && (score <= alpha || score >= beta); researches++) {
         D( m_debug.Increment("AspirationWindow: Out of bounds: Researches: " + std::to_string(researches) ); );
 
-        // Display fail-low info
-        if(score <= alpha) {
-            UciOutput(m_pv.PVString(), score, BOUND_TYPE::UPPER_BOUND);
-        }
+        // Display lowerbound / upperbound info
+        BOUND_TYPE bound = (score <= alpha) ? BOUND_TYPE::UPPER_BOUND
+                                            : BOUND_TYPE::LOWER_BOUND;
+        UciOutput(m_pv.PVString(), score, bound);
 
         // Asymmetrical incremental aspiration
         window = window * ASPIRATION_WINDOW_MULTIPLIER;
@@ -282,10 +282,12 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
     m_pv.ClearPly(m_ply);
 
     MoveList moves = MoveGenerator::GenerateMoves(board);
-
     D( if(depth == 1) P("Number of moves in root position: " << moves.size()) );
 
     SortMoves(board, moves, Hash::tt, m_heuristics, m_ply);
+
+    if(!m_bestMove.MoveType() && !moves.empty())
+        m_bestMove = moves[0]; // Life jacket if first move at depth 1 is not completed
 
     int moveNumber = 0;
 
@@ -297,7 +299,7 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
             P( "RootMax: " << move.Notation() );
 
         // Display the root move under analysis and update the counters
-        if(UCI_OUTPUT && m_elapsedTime > UCI_OUTPUT_CURRMOVE_MINTIME) {
+        if(UCI_OUTPUT && m_elapsedTime > UCI_OUTPUT_ROOTMAX_MINTIME) {
             m_elapsedTime = ElapsedTime();
             m_nps = CalculateNPS();
 
@@ -349,23 +351,22 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
             D( m_debug.Increment("RootMax: AlphaBeta: Update Alpha (score > alpha)") );
             alpha = score;
 
+            m_bestMove = move;
+            m_bestScore = score;
+
             m_pv.Update(m_ply, move);
 
-            if(m_elapsedTime > UCI_OUTPUT_CURRMOVE_MINTIME) {
-                BOUND_TYPE bound = (score >= beta) ? BOUND_TYPE::LOWER_BOUND
-                                                   : BOUND_TYPE::EXACT;
-                UciOutput(m_pv.PVString(), score, bound);
-            }
+            if(m_elapsedTime > UCI_OUTPUT_ROOTMAX_MINTIME)
+                UciOutput(m_pv.PVString(), score, BOUND_TYPE::LOWER_BOUND);
         }
     }
 
     // Store "exact" score in transposition table if search finished within search bounds
     bool withinBounds = (bestScore > alphaOriginal) && (bestScore < beta);
     if(!m_stop && withinBounds) {
-        m_bestMove = bestMove;
-        m_bestScore = bestScore;
+        assert(bestMove == m_bestMove && bestScore == m_bestScore);
+        D( m_debug.Increment("RootMax: AlphaBeta: TT Store Exact") );
 
-        D( m_debug.Increment("RootMax: AlphaBeta: Exact") );
         Hash::tt.Store(board.ZKey(), bestScore, TTENTRY_TYPE::EXACT, bestMove, depth, m_ply, m_searchCount);
     }
 

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -304,6 +304,7 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
             m_nps = CalculateNPS();
 
             std::cout << "info depth " << m_depth
+                      << " seldepth " << m_selPly
                       << " currmovenumber " << moveNumber
                       << " currmove " << move.Notation()
                       << " time " << m_elapsedTime

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -243,7 +243,7 @@ int Search::AspirationWindow(Board& board, const int depth, const int bestScore)
         // Display lowerbound / upperbound info
         BOUND_TYPE bound = (score <= alpha) ? BOUND_TYPE::UPPER_BOUND
                                             : BOUND_TYPE::LOWER_BOUND;
-        UciOutput(m_pv.PVString(), score, bound);
+        UciOutput(m_bestMove.Notation(), score, bound);
 
         // Asymmetrical incremental aspiration
         window = window * ASPIRATION_WINDOW_MULTIPLIER;


### PR DESCRIPTION
Report in UCI the `bestmove` found so far even in unfinished-depth searches (ELO gain expected).

In addition, several improvements to UCI display:
- Display `lowerbound` / `upperbound` when falling out of AW bounds.
- Display the **updated score and PV** after the best move search has been completed at the current unfinished depth. As `lowerbound`.
- Display `tbHits` in currmove only if there are any.
- Fun fact: fix a bug when extremely short searches (e.g. `go nodes 1`) report an illegal move ("0000"). This happened when the first move in depth 1 is not fully searched.

```
bench 3510591

Elo   | 15.20 +- 17.05 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.09 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 892 W: 303 L: 264 D: 325
Penta | [33, 86, 179, 105, 43]

Elo   | 13.66 +- 15.37 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 840 W: 267 L: 234 D: 339
Penta | [13, 96, 183, 101, 27]
```

Repeat with `m_bestScore` updated after beta cutoffs:
```
Elo   | 14.72 +- 16.76 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 850 W: 310 L: 274 D: 266
Penta | [28, 82, 174, 108, 33]
```