### PR TITLE
robustness: AW fail-soft

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -238,9 +238,9 @@ int Search::AspirationWindow(Board& board, const int depth, const int bestScore)
         // Asymmetrical incremental aspiration
         window = window * ASPIRATION_WINDOW_MULTIPLIER;
         if(score <= alpha) {
-            alpha = bestScore - window;
+            alpha = score - window;
         } else if(score >= beta) {
-            beta = bestScore + window;
+            beta = score + window;
         }
 
         if(researches == 4 || IsWinValue(score)) {


### PR DESCRIPTION
**Fail-soft consistency in Aspiration Windows** (AW)

```
bench 2883188 (previous: 2855713)

Failed
```