### PR TITLE
enhance: draw repetition

### DIFF
--- a/include/Board.h
+++ b/include/Board.h
@@ -63,7 +63,7 @@ public:
     bool IsAttacked(COLOR color, int square) const;
     bool IsCheck();
     bool IsCheckAnyColor();
-    bool IsRepetitionDraw(int searchPly = 0);
+    bool IsRepetitionDraw() const;
     void Mirror();
     int SquareToIndex(std::string square) const;
 

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -330,24 +330,19 @@ bool Board::IsCheckAnyColor() {
     return check_active || check_inactive;
 }
 
-bool Board::IsRepetitionDraw(int searchPly) {
-    int rep = 1;
+// Detects a position repetition within a search (same Zobrist Key)
+bool Board::IsRepetitionDraw() const {
+    const int rule_limit = (int)m_fiftyrule;
+    const int ply_limit = m_ply - m_initialPly;
 
-    int imax = (int)m_fiftyrule; // Logical limit
-    int ply = m_ply - m_initialPly; // Physical limit
+    const int limit = std::min(rule_limit, ply_limit);
 
-    int i = 4;
-    while(i <= imax && i <= ply) {
-        if(ZKey() == m_history[m_ply - i].zkey) rep++;
-
-        // 2-repetitions are enough within the search
-        if(rep == 2 && searchPly >= i) return true;
-
-        // 3-repetitions are needed in real game
-        if(rep == 3) return true;
-
-        i += 2;
+    for(int i = 4; i <= limit; i += 2) {
+        if(m_history[m_ply - i].zkey == ZKey()) {
+            return true;
+        }
     }
+
     return false;
 }
 

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -381,7 +381,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
         D( m_debug.Increment("NegaMax: Draw: FiftyRule") );
         return DRAW_SCORE(m_ply);
     }
-    if(board.IsRepetitionDraw(m_ply)) {
+    if(board.IsRepetitionDraw()) {
         D( m_debug.Increment("NegaMax: Draw: Repetition") );
         return DRAW_SCORE(m_ply);
     }

--- a/tests/test-Board.cpp
+++ b/tests/test-Board.cpp
@@ -123,10 +123,10 @@ TEST(BoardTest, IsRepetitionDraw) {
     board.MakeMove("g6h6"); EXPECT_EQ(board.IsRepetitionDraw(), false);
     board.MakeMove("g3h4"); EXPECT_EQ(board.IsRepetitionDraw(), false);
     board.MakeMove("h6g6"); EXPECT_EQ(board.IsRepetitionDraw(), false);
-    board.MakeMove("h4g3"); EXPECT_EQ(board.IsRepetitionDraw(), false); //1st repetition
-    board.MakeMove("g6h6"); EXPECT_EQ(board.IsRepetitionDraw(), false);
-    board.MakeMove("g3h4"); EXPECT_EQ(board.IsRepetitionDraw(), false);
-    board.MakeMove("h6g6"); EXPECT_EQ(board.IsRepetitionDraw(), false);
+    board.MakeMove("h4g3"); EXPECT_EQ(board.IsRepetitionDraw(), true); //1st repetition
+    board.MakeMove("g6h6"); EXPECT_EQ(board.IsRepetitionDraw(), true);
+    board.MakeMove("g3h4"); EXPECT_EQ(board.IsRepetitionDraw(), true);
+    board.MakeMove("h6g6"); EXPECT_EQ(board.IsRepetitionDraw(), true);
     board.MakeMove("h4g3"); EXPECT_EQ(board.IsRepetitionDraw(), true); //2nd repetition
     board.MakeMove("g6h6"); EXPECT_EQ(board.IsRepetitionDraw(), true);
     board.MakeMove("g3h4"); EXPECT_EQ(board.IsRepetitionDraw(), true);


### PR DESCRIPTION
Rewrite the **Draw Repetition detection** to return draw after the first repetition, regardless of move history.

```
bench 2855713

Elo   | 3.03 +- 10.86 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 2062 W: 695 L: 677 D: 690
Penta | [74, 221, 436, 213, 87]

Elo   | -1.11 +- 7.36 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 4078 W: 1286 L: 1299 D: 1493
Penta | [134, 457, 854, 476, 118]
```