### PR TITLE
bugfix: generate enpassant moves that block a check

### DIFF
--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -365,8 +365,9 @@ namespace {
                 int fromSq = BitscanForward( FromBitboard(toBitboard) );
                 Bitboard enemyPawn = RSouth(board.EnPassantSquare());
 
-                //Check legality
-                Bitboard blockers = context.allPieces ^ SquareBB(fromSq) ^ enemyPawn; //remove the own and enemy pawns
+                // Check legality
+                // For blockers: move our pawn and remove the enemy pawn
+                Bitboard blockers = (context.allPieces ^ SquareBB(fromSq) ^ enemyPawn) | toBitboard;
                 int kingSquare = BitscanForward( board.Piece(context.color,KING) );
                 if(board.AttackersTo(context.color, kingSquare, blockers) & ~enemyPawn) //any attackers that are not the enemy pawn?
                     continue;

--- a/tests/test-Perft.cpp
+++ b/tests/test-Perft.cpp
@@ -13,13 +13,34 @@ int main(int argc, char** argv) {
     return RUN_ALL_TESTS();
 }
 
-//MoveGenerator
+// =========================
+// ===== MoveGenerator =====
+// =========================
 TEST(MoveGenerator, StartingPosition) {
     Board board;
     MoveList moves = MoveGenerator::GenerateMoves(board);
     EXPECT_EQ(moves.size(), 20);
 }
+TEST(MoveGenerator, EnpassantBlocker) {
+    Board board;
+    board.SetFen("k3r3/8/8/3Pp3/8/8/8/4K3 w - e6 0 1");
+    MoveList moves = MoveGenerator::GenerateMoves(board);
 
+    bool hasEnpassant = false;
+    for(const auto move : moves) {
+        if(move.MoveType() == ENPASSANT) {
+            hasEnpassant = true;
+            break;
+        }
+    }
+
+    EXPECT_TRUE(hasEnpassant); // dxe6ep should be included
+    EXPECT_EQ(moves.size(), 7);
+}
+
+// =================
+// ===== Perft =====
+// =================
 //https://www.chessprogramming.org/Perft_Results
 TEST(Perft, StartingPosition) {
     Board board;


### PR DESCRIPTION
**Fix: generate en-passant moves that block checks**

Previously, `Casanchess` would not generate these moves at all!! 🫨 
Shockingly that this bug was there during years and passed all `perft` checks! Fortunately, these moves are so uncommon that almost had no effect on playing strength.
The fix is now applied and a new test is added with the position below.

## Example
In this position, black just played `e7e5` so an enpassant is possible for white.
The capture is safe since the white pawn would block the rook check.

<img src="https://lichess1.org/export/fen.gif?fen=k3r3%2F8%2F8%2F3Pp3%2F8%2F8%2F8%2F4K3%20w%20-%20e6%200%201" width="300" alt="Chess Position" />

`k3r3/8/8/3Pp3/8/8/8/4K3 w - e6 0 1`

## Bench and SPRT
```
bench 2956027 (same as before)

Elo   | 1.01 +- 9.58 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 2750 W: 937 L: 929 D: 884
Penta | [108, 304, 550, 298, 115]
```