### PR TITLE
performance: in king movements, full-update NNUE only if king changes bucket

### DIFF
--- a/include/NNUE.h
+++ b/include/NNUE.h
@@ -4,9 +4,23 @@
 
 #include <string>
 
-const int NNUE_SIZE = 128;
-const int NNUE_FEATURES = 32*64*5*2; //kingBuckets * square * pieceType * color
-const int CONVERSION_FACTOR = INFINITE_I16 / 3;
+constexpr int NNUE_SIZE = 128;
+constexpr int NNUE_FEATURES = 32*64*5*2; //kingBuckets * square * pieceType * color
+
+namespace NNUEConstants {
+    constexpr int BLACK_PERSPECTIVE_XOR = 56;
+    constexpr int CONVERSION_FACTOR = INFINITE_I16 / 3;
+    constexpr u8 KING_BUCKETS[64] = {
+        0, 1, 2, 3, 4, 5, 6, 7,
+        8, 9,10,11,12,13,14,15,
+       16,16,17,17,18,18,19,19,
+       20,20,21,21,22,22,23,23,
+       24,24,25,25,26,26,27,27,
+       24,24,25,25,26,26,27,27,
+       28,28,29,29,30,30,31,31,
+       28,28,29,29,30,30,31,31
+   };
+}
 
 struct Network;
 

--- a/src/MoveMaker.cpp
+++ b/src/MoveMaker.cpp
@@ -89,14 +89,27 @@ void MoveMaker::MakeMove(Board& board, Move move, bool update_nnue) {
 
     //NNUE update
     if(update_nnue && !UCI_CLASSICAL_EVAL) {
-        if(pieceType != KING && (moveType == NORMAL || moveType == DOUBLE_PUSH || moveType == CAPTURE)) { //Incremental update
-            nnue.Inputs_MovePiece(color, (pieceType-1), fromSq, toSq);
+        bool isKing = (pieceType == KING);
+        bool bucketChanged = false;
+
+        if(isKing) {
+            int fromSq_POV = (color == WHITE) ? fromSq : fromSq ^ NNUEConstants::BLACK_PERSPECTIVE_XOR;
+            int toSq_POV = (color == WHITE) ? toSq : toSq ^ NNUEConstants::BLACK_PERSPECTIVE_XOR;
+            bucketChanged = NNUEConstants::KING_BUCKETS[fromSq_POV] != NNUEConstants::KING_BUCKETS[toSq_POV];
+        }
+
+        // Full update
+        if( move.IsPromotion() || moveType == ENPASSANT || moveType == CASTLING || (isKing && bucketChanged) ) {
+            nnue.Inputs_FullUpdate();
+        }
+        // Incremental update
+        else {
+            if(!isKing)
+                nnue.Inputs_MovePiece(color, (pieceType-1), fromSq, toSq);
 
             if(moveType == CAPTURE) {
                 nnue.Inputs_RemovePiece((1-color), (move.CapturedType()-1), toSq);
             }
-        } else {
-            nnue.Inputs_FullUpdate();
         }
     }
 

--- a/src/NNUE.cpp
+++ b/src/NNUE.cpp
@@ -25,20 +25,9 @@
 #include <cstring>
 #include <fstream>
 
-namespace NNUEConstants {
-    constexpr u8 KING_BUCKETS[64] = {
-        0, 1, 2, 3, 4, 5, 6, 7,
-        8, 9,10,11,12,13,14,15,
-       16,16,17,17,18,18,19,19,
-       20,20,21,21,22,22,23,23,
-       24,24,25,25,26,26,27,27,
-       24,24,25,25,26,26,27,27,
-       28,28,29,29,30,30,31,31,
-       28,28,29,29,30,30,31,31
-   };
+namespace {
    constexpr int KING_BUCKET_MULTIPLIER = 640;
    constexpr int PIECE_INDEX_MULTIPLIER = 64;
-   constexpr int BLACK_PERSPECTIVE_XOR = 56;
 }
 
 NNUE::NNUE() {
@@ -68,7 +57,7 @@ void NNUE::Load(std::string filepath) {
     file.read((char*)nnue_storage, sizeof(NetworkStorage));
 
     for(size_t i = 0; i < (sizeof(nnue_storage->w1) / sizeof(nnue_storage->w1[0])); i++) {
-        m_network.w1[i] = (float)nnue_storage->w1[i] / CONVERSION_FACTOR;
+        m_network.w1[i] = (float)nnue_storage->w1[i] / NNUEConstants::CONVERSION_FACTOR;
     }
 
     size_t size = sizeof(nnue_storage->b1);
@@ -154,8 +143,8 @@ void NNUE::Inputs_AddPiece(int color, int pieceType, int square) {
     const int square_w = square;
 	const int square_b = square ^ NNUEConstants::BLACK_PERSPECTIVE_XOR;
 
-    const int feature_w = (NNUEConstants::KING_BUCKET_MULTIPLIER * kingBucket_w) + (NNUEConstants::PIECE_INDEX_MULTIPLIER * index_w) + (square_w);
-	const int feature_b = (NNUEConstants::KING_BUCKET_MULTIPLIER * kingBucket_b) + (NNUEConstants::PIECE_INDEX_MULTIPLIER * index_b) + (square_b);
+    const int feature_w = (KING_BUCKET_MULTIPLIER * kingBucket_w) + (PIECE_INDEX_MULTIPLIER * index_w) + (square_w);
+	const int feature_b = (KING_BUCKET_MULTIPLIER * kingBucket_b) + (PIECE_INDEX_MULTIPLIER * index_b) + (square_b);
 
     assert(feature_w <= NNUE_FEATURES);
     assert(feature_b <= NNUE_FEATURES);
@@ -179,8 +168,8 @@ void NNUE::Inputs_RemovePiece(int color, int pieceType, int square) {
     const int square_w = square;
 	const int square_b = square ^ NNUEConstants::BLACK_PERSPECTIVE_XOR;
 
-    const int feature_w = (NNUEConstants::KING_BUCKET_MULTIPLIER * kingBucket_w) + (NNUEConstants::PIECE_INDEX_MULTIPLIER * index_w) + (square_w);
-	const int feature_b = (NNUEConstants::KING_BUCKET_MULTIPLIER * kingBucket_b) + (NNUEConstants::PIECE_INDEX_MULTIPLIER * index_b) + (square_b);
+    const int feature_w = (KING_BUCKET_MULTIPLIER * kingBucket_w) + (PIECE_INDEX_MULTIPLIER * index_w) + (square_w);
+	const int feature_b = (KING_BUCKET_MULTIPLIER * kingBucket_b) + (PIECE_INDEX_MULTIPLIER * index_b) + (square_b);
 
     assert(feature_w <= NNUE_FEATURES);
     assert(feature_b <= NNUE_FEATURES);
@@ -207,11 +196,11 @@ void NNUE::Inputs_MovePiece(int color, int pieceType, int fromSq, int toSq) {
     const int toSq_w = toSq;
 	const int toSq_b = toSq ^ NNUEConstants::BLACK_PERSPECTIVE_XOR;
 
-    const int feature_from_w = (NNUEConstants::KING_BUCKET_MULTIPLIER * kingBucket_w) + (NNUEConstants::PIECE_INDEX_MULTIPLIER * index_w) + (fromSq_w);
-	const int feature_from_b = (NNUEConstants::KING_BUCKET_MULTIPLIER * kingBucket_b) + (NNUEConstants::PIECE_INDEX_MULTIPLIER * index_b) + (fromSq_b);
+    const int feature_from_w = (KING_BUCKET_MULTIPLIER * kingBucket_w) + (PIECE_INDEX_MULTIPLIER * index_w) + (fromSq_w);
+	const int feature_from_b = (KING_BUCKET_MULTIPLIER * kingBucket_b) + (PIECE_INDEX_MULTIPLIER * index_b) + (fromSq_b);
 
-    const int feature_to_w = (NNUEConstants::KING_BUCKET_MULTIPLIER * kingBucket_w) + (NNUEConstants::PIECE_INDEX_MULTIPLIER * index_w) + (toSq_w);
-	const int feature_to_b = (NNUEConstants::KING_BUCKET_MULTIPLIER * kingBucket_b) + (NNUEConstants::PIECE_INDEX_MULTIPLIER * index_b) + (toSq_b);
+    const int feature_to_w = (KING_BUCKET_MULTIPLIER * kingBucket_w) + (PIECE_INDEX_MULTIPLIER * index_w) + (toSq_w);
+	const int feature_to_b = (KING_BUCKET_MULTIPLIER * kingBucket_b) + (PIECE_INDEX_MULTIPLIER * index_b) + (toSq_b);
 
     assert(feature_from_w <= NNUE_FEATURES);
     assert(feature_from_b <= NNUE_FEATURES);

--- a/src/nnue_convert/NNUE_Convert.cpp
+++ b/src/nnue_convert/NNUE_Convert.cpp
@@ -29,7 +29,7 @@ void Convert(std::string ifilename, std::string ofilename) {
     for(uint col = 0; col < ARCH[L1][COL]; col++) {
         for(uint row = 0; row < ARCH[L1][ROW]; row++) {
             float decimal = GetNumber(ifile);
-            int converted_value = CastInt(decimal * CONVERSION_FACTOR);
+            int converted_value = CastInt(decimal * NNUEConstants::CONVERSION_FACTOR);
             assert(std::abs(converted_value) < INFINITE_I16);
             if(std::abs(converted_value) >= INFINITE_I16)
                 std::cout << "Watch out! Int16 overflow (" << decimal << ")" << std::endl;


### PR DESCRIPTION
Performance: in king movements, full-update NNUE **only** if king changes bucket

```
bench 2956027

Elo   | 4.24 +- 11.77 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1804 W: 617 L: 595 D: 592
Penta | [67, 196, 363, 200, 76]
```