### PR TITLE
performance: NNUE accumulators per ply

### DIFF
--- a/include/NNUE.h
+++ b/include/NNUE.h
@@ -31,30 +31,33 @@ public:
     bool IsLoaded() const { return m_isLoaded; }
     std::string GetPath() const { return m_filepath; }
 
-    int Evaluate(int color);
+    int Evaluate(int color, int ply);
 
     void SetPieces(int color, uint64_t& pieces);
-    void SavePosition(int ply);
-    void RestorePosition(int ply);
+    // void SavePosition(int ply);
+    // void RestorePosition(int ply);
 
-    void Inputs_FullUpdate();
-    void Inputs_AddPiece(int color, int pieceType, int square);
-    void Inputs_RemovePiece(int color, int pieceType, int square);
-    void Inputs_MovePiece(int color, int pieceType, int fromSq, int toSq);
+    void Inputs_FullUpdate(int ply);
+    void Inputs_AddPiece(int color, int pieceType, int square, int ply);
+    void Inputs_RemovePiece(int color, int pieceType, int square, int ply);
+    void Inputs_MovePiece(int color, int pieceType, int fromSq, int toSq, int ply);
+
+    void CopyAccumulator(int fromPly, int toPly);
 
 private:
     //Helpers
     float Clamp(float n);
+
+    //Compute
     void ComputeLayer(float* inputLayer, float* outputLayer, float* biases, float* weights, int dimInput, int dimOutput, bool with_ReLU);
 
     //Current state
     Bitboard* m_pieces[2];
-    alignas(32) float m_accumulator[2][NNUE_SIZE];
-    //Backups
-    alignas(32) float m_backupAccumulator[MAX_PLY_HISTORY][2][NNUE_SIZE];
 
     bool m_isLoaded;
     std::string m_filepath;
+    
+    alignas(32) float m_accumulator[MAX_PLY_HISTORY][2][NNUE_SIZE]; // [PLY][COLOR][NNUE_SIZE]
 };
 
 //Network architecture

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -458,6 +458,6 @@ void Board::InitStateAndHistory() {
     if(!UCI_CLASSICAL_EVAL) {
         nnue.SetPieces(WHITE, m_pieces[WHITE][NO_PIECE]);
         nnue.SetPieces(BLACK, m_pieces[BLACK][NO_PIECE]);
-        nnue.Inputs_FullUpdate();
+        nnue.Inputs_FullUpdate(m_ply);
     }
 }

--- a/src/Evaluation.cpp
+++ b/src/Evaluation.cpp
@@ -527,7 +527,7 @@ int Evaluation::Evaluate(const Board& board) {
         eval = ClassicalEvaluation(board);
     } else {
         int color = board.ActivePlayer();
-        eval = nnue.Evaluate(color);
+        eval = nnue.Evaluate(color, board.Ply());
     }
 
     return eval;

--- a/src/MoveMaker.cpp
+++ b/src/MoveMaker.cpp
@@ -16,12 +16,10 @@ void MoveMaker::MakeMove(Board& board, Move move, bool update_nnue) {
     assert(fromSq >= 0 && fromSq < 64);
     assert(toSq >= 0 && toSq < 64);
 
-    //Before any change in the board state
-    if(update_nnue && !UCI_CLASSICAL_EVAL)
-        nnue.SavePosition(board.m_ply);
-
     //Increase ply
     board.m_ply++;
+    const uint ply = board.m_ply;
+
     if(color == BLACK)
         board.m_moveNumber++;
     //Fifty-rule
@@ -74,12 +72,12 @@ void MoveMaker::MakeMove(Board& board, Move move, bool update_nnue) {
     board.m_zobristKey.UpdateColor();
 
     //Store irreversible information (to help a later TakeMove)
-    assert(board.m_ply < MAX_PLY_HISTORY);
-    board.m_history[board.m_ply].fiftyrule = board.m_fiftyrule;
-    board.m_history[board.m_ply].castling = board.m_castlingRights;
-    board.m_history[board.m_ply].zkey = board.ZKey();
-    board.m_history[board.m_ply].enpassant = board.m_enPassantSquare;
-    board.m_history[board.m_ply].move = move;
+    assert(ply < MAX_PLY_HISTORY);
+    board.m_history[ply].fiftyrule = board.m_fiftyrule;
+    board.m_history[ply].castling = board.m_castlingRights;
+    board.m_history[ply].zkey = board.ZKey();
+    board.m_history[ply].enpassant = board.m_enPassantSquare;
+    board.m_history[ply].move = move;
 
     //Update helper bitboards
     board.UpdateBitboards();
@@ -89,6 +87,9 @@ void MoveMaker::MakeMove(Board& board, Move move, bool update_nnue) {
 
     //NNUE update
     if(update_nnue && !UCI_CLASSICAL_EVAL) {
+        // Copy Accumulator from previous ply
+        nnue.CopyAccumulator(ply-1, ply);
+
         bool isKing = (pieceType == KING);
         bool bucketChanged = false;
 
@@ -100,15 +101,15 @@ void MoveMaker::MakeMove(Board& board, Move move, bool update_nnue) {
 
         // Full update
         if( move.IsPromotion() || moveType == ENPASSANT || moveType == CASTLING || (isKing && bucketChanged) ) {
-            nnue.Inputs_FullUpdate();
+            nnue.Inputs_FullUpdate(ply);
         }
         // Incremental update
         else {
             if(!isKing)
-                nnue.Inputs_MovePiece(color, (pieceType-1), fromSq, toSq);
+                nnue.Inputs_MovePiece(color, (pieceType-1), fromSq, toSq, ply);
 
             if(moveType == CAPTURE) {
-                nnue.Inputs_RemovePiece((1-color), (move.CapturedType()-1), toSq);
+                nnue.Inputs_RemovePiece((1-color), (move.CapturedType()-1), toSq, ply);
             }
         }
     }
@@ -185,10 +186,6 @@ void MoveMaker::TakeMove(Board& board, Move move) {
     //Reset check calculation
     board.m_checkCalculated = false;
 
-    //Retrieve NNUE
-    if(!UCI_CLASSICAL_EVAL)
-        nnue.RestorePosition(board.m_ply);
-
     //Asserts
     assert(BoardIntegrityChecker::CheckIntegrity(board));
     assert(board.m_allpieces & SquareBB(fromSq));
@@ -205,7 +202,13 @@ void MoveMaker::MakeNull(Board& board) {
     Move move = Move();
 
     board.m_ply++;
-    assert(board.m_ply < MAX_PLY_HISTORY);
+    const uint ply = board.m_ply;
+    assert(ply < MAX_PLY_HISTORY);
+
+    // Copy the NNUE accumulator from the previous ply
+    if(!UCI_CLASSICAL_EVAL) {
+        nnue.CopyAccumulator(ply-1, ply);
+    }
 
     //Reset en-passant square
     if(board.m_enPassantSquare) {
@@ -218,11 +221,11 @@ void MoveMaker::MakeNull(Board& board) {
     board.m_zobristKey.UpdateColor();
 
     //Store irreversible information (to help a later TakeMove)
-    board.m_history[board.m_ply].fiftyrule = board.m_fiftyrule;
-    board.m_history[board.m_ply].castling = board.m_castlingRights;
-    board.m_history[board.m_ply].zkey = board.ZKey();
-    board.m_history[board.m_ply].enpassant = board.m_enPassantSquare;
-    board.m_history[board.m_ply].move = move;
+    board.m_history[ply].fiftyrule = board.m_fiftyrule;
+    board.m_history[ply].castling = board.m_castlingRights;
+    board.m_history[ply].zkey = board.ZKey();
+    board.m_history[ply].enpassant = board.m_enPassantSquare;
+    board.m_history[ply].move = move;
 
     //Reset check calculation
     board.m_checkCalculated = false;
@@ -237,12 +240,13 @@ void MoveMaker::TakeNull(Board& board) {
 
     assert(board.m_ply != 0);
     board.m_ply--;
+    const uint ply = board.m_ply;
 
     //Retrieve state
-    board.m_fiftyrule = board.m_history[board.m_ply].fiftyrule;
-    board.m_castlingRights = board.m_history[board.m_ply].castling;
-    board.m_zobristKey.SetKey( board.m_history[board.m_ply].zkey );
-    board.m_enPassantSquare = board.m_history[board.m_ply].enpassant;
+    board.m_fiftyrule = board.m_history[ply].fiftyrule;
+    board.m_castlingRights = board.m_history[ply].castling;
+    board.m_zobristKey.SetKey( board.m_history[ply].zkey );
+    board.m_enPassantSquare = board.m_history[ply].enpassant;
 
     //Reset check calculation
     board.m_checkCalculated = false;

--- a/src/MoveMaker.cpp
+++ b/src/MoveMaker.cpp
@@ -3,8 +3,6 @@
 #include "NNUE.h"
 #include "Uci.h"
 
-#include <cstring> //for memcpy, delete this
-
 void MoveMaker::MakeMove(Board& board, Move move, bool update_nnue) {    
     // Get move information
     COLOR color = board.ActivePlayer();

--- a/src/NNUE.cpp
+++ b/src/NNUE.cpp
@@ -85,11 +85,15 @@ Utils::Clock clock_eval;
 int NNUE::Evaluate(int color, int ply) {
     //Layer 1
     alignas(32) float o1[ ARCH[L2][ROW] ];
+
+    float* acc_active = m_accumulator[ply][color];
+    float* acc_inactive = m_accumulator[ply][1-color];
+
     for(uint i = 0; i < NNUE_SIZE; i++) {
-        o1[i            ] = Clamp(m_accumulator[ply][color][i]);
+        o1[i] = Clamp(acc_active[i]);
     }
     for(uint i = 0; i < NNUE_SIZE; i++) {
-        o1[i + NNUE_SIZE] = Clamp(m_accumulator[ply][1-color][i]);
+        o1[i + NNUE_SIZE] = Clamp(acc_inactive[i]);
     }
 
     //Layers 2,3,4
@@ -117,9 +121,12 @@ void NNUE::SetPieces(int color, uint64_t& pieces) {
 }
 
 void NNUE::Inputs_FullUpdate(int ply) {
+    float* acc_w = m_accumulator[ply][0];
+    float* acc_b = m_accumulator[ply][1];
+
     for(int i=0; i < NNUE_SIZE; i++) {
-        m_accumulator[ply][0][i] = m_network.b1[i];
-        m_accumulator[ply][1][i] = m_network.b1[i];
+        acc_w[i] = m_network.b1[i];
+        acc_b[i] = m_network.b1[i];
     }
 
     for(int color = WHITE; color <= BLACK; color++) {
@@ -151,9 +158,12 @@ void NNUE::Inputs_AddPiece(int color, int pieceType, int square, int ply) {
     assert(feature_w <= NNUE_FEATURES);
     assert(feature_b <= NNUE_FEATURES);
 
+    float* acc_w = m_accumulator[ply][0];
+    float* acc_b = m_accumulator[ply][1];
+
     for(int i = 0; i < NNUE_SIZE; i++) {
-        m_accumulator[ply][0][i] += m_network.w1[NNUE_SIZE * feature_w + i];
-        m_accumulator[ply][1][i] += m_network.w1[NNUE_SIZE * feature_b + i];
+        acc_w[i] += m_network.w1[NNUE_SIZE * feature_w + i];
+        acc_b[i] += m_network.w1[NNUE_SIZE * feature_b + i];
     }
 }
 
@@ -176,9 +186,12 @@ void NNUE::Inputs_RemovePiece(int color, int pieceType, int square, int ply) {
     assert(feature_w <= NNUE_FEATURES);
     assert(feature_b <= NNUE_FEATURES);
 
+    float* acc_w = m_accumulator[ply][0];
+    float* acc_b = m_accumulator[ply][1];
+
     for(int i = 0; i < NNUE_SIZE; i++) {
-        m_accumulator[ply][0][i] -= m_network.w1[NNUE_SIZE * feature_w + i];
-        m_accumulator[ply][1][i] -= m_network.w1[NNUE_SIZE * feature_b + i];
+        acc_w[i] -= m_network.w1[NNUE_SIZE * feature_w + i];
+        acc_b[i] -= m_network.w1[NNUE_SIZE * feature_b + i];
     }
 }
 
@@ -210,12 +223,15 @@ void NNUE::Inputs_MovePiece(int color, int pieceType, int fromSq, int toSq, int 
     assert(feature_to_w <= NNUE_FEATURES);
     assert(feature_to_b <= NNUE_FEATURES);
 
-    for(int i = 0; i < NNUE_SIZE; i++) {
-        m_accumulator[ply][0][i] -= m_network.w1[NNUE_SIZE * feature_from_w + i];
-        m_accumulator[ply][1][i] -= m_network.w1[NNUE_SIZE * feature_from_b + i];
+    float* acc_w = m_accumulator[ply][0];
+    float* acc_b = m_accumulator[ply][1];
 
-        m_accumulator[ply][0][i] += m_network.w1[NNUE_SIZE * feature_to_w + i];
-        m_accumulator[ply][1][i] += m_network.w1[NNUE_SIZE * feature_to_b + i];
+    for(int i = 0; i < NNUE_SIZE; i++) {
+        acc_w[i] += m_network.w1[NNUE_SIZE * feature_to_w + i];
+        acc_b[i] += m_network.w1[NNUE_SIZE * feature_to_b + i];
+
+        acc_w[i] -= m_network.w1[NNUE_SIZE * feature_from_w + i];
+        acc_b[i] -= m_network.w1[NNUE_SIZE * feature_from_b + i];
     }
 }
 

--- a/src/NNUE.cpp
+++ b/src/NNUE.cpp
@@ -34,9 +34,11 @@ NNUE::NNUE() {
     m_isLoaded = false;
     m_filepath = "network-20260712.nnue";
 
-    for(int i = 0; i < NNUE_SIZE; i++) {
-        m_accumulator[0][i] = 0;
-        m_accumulator[1][i] = 0;
+    for(int ply = 0; ply < MAX_PLY_HISTORY; ply++) {
+        for(int i = 0; i < NNUE_SIZE; i++) {
+            m_accumulator[ply][0][i] = 0;
+            m_accumulator[ply][1][i] = 0;
+        }
     }
 }
 
@@ -80,14 +82,14 @@ void NNUE::Load(std::string filepath) {
 #include "Utils.h"
 Utils::Clock clock_eval;
 
-int NNUE::Evaluate(int color) {
+int NNUE::Evaluate(int color, int ply) {
     //Layer 1
     alignas(32) float o1[ ARCH[L2][ROW] ];
     for(uint i = 0; i < NNUE_SIZE; i++) {
-        o1[i            ] = Clamp(m_accumulator[color][i]);
+        o1[i            ] = Clamp(m_accumulator[ply][color][i]);
     }
     for(uint i = 0; i < NNUE_SIZE; i++) {
-        o1[i + NNUE_SIZE] = Clamp(m_accumulator[1-color][i]);
+        o1[i + NNUE_SIZE] = Clamp(m_accumulator[ply][1-color][i]);
     }
 
     //Layers 2,3,4
@@ -102,35 +104,35 @@ int NNUE::Evaluate(int color) {
     return CastInt(o4[0] * 100);
 }
 
-void NNUE::SavePosition(int ply) {
-    std::memcpy(&m_backupAccumulator[ply], &m_accumulator, sizeof(m_accumulator));
-}
+// void NNUE::SavePosition(int ply) {
+//     std::memcpy(&m_backupAccumulator[ply], &m_accumulator, sizeof(m_accumulator));
+// }
 
-void NNUE::RestorePosition(int ply) {
-    std::memcpy(&m_accumulator, &m_backupAccumulator[ply], sizeof(m_backupAccumulator[ply]));
-}
+// void NNUE::RestorePosition(int ply) {
+//     std::memcpy(&m_accumulator, &m_backupAccumulator[ply], sizeof(m_backupAccumulator[ply]));
+// }
 
 void NNUE::SetPieces(int color, uint64_t& pieces) {
     m_pieces[color] = &pieces;
 }
 
-void NNUE::Inputs_FullUpdate() {
+void NNUE::Inputs_FullUpdate(int ply) {
     for(int i=0; i < NNUE_SIZE; i++) {
-        m_accumulator[0][i] = m_network.b1[i];
-        m_accumulator[1][i] = m_network.b1[i];
+        m_accumulator[ply][0][i] = m_network.b1[i];
+        m_accumulator[ply][1][i] = m_network.b1[i];
     }
 
     for(int color = WHITE; color <= BLACK; color++) {
         for(int pieceType = PAWN; pieceType <= QUEEN; pieceType++) {
             Bitboard bitboard = m_pieces[color][pieceType];
             for(int square : BitboardIterator(bitboard)) {
-                Inputs_AddPiece(color, pieceType-1, square);
+                Inputs_AddPiece(color, pieceType-1, square, ply);
             }
         }
     }
 }
 
-void NNUE::Inputs_AddPiece(int color, int pieceType, int square) {
+void NNUE::Inputs_AddPiece(int color, int pieceType, int square, int ply) {
     const int kingSquare_w = BitscanForward(m_pieces[WHITE][KING]);
     const int kingSquare_b = BitscanForward(m_pieces[BLACK][KING]) ^ NNUEConstants::BLACK_PERSPECTIVE_XOR;
 
@@ -150,12 +152,12 @@ void NNUE::Inputs_AddPiece(int color, int pieceType, int square) {
     assert(feature_b <= NNUE_FEATURES);
 
     for(int i = 0; i < NNUE_SIZE; i++) {
-        m_accumulator[0][i] += m_network.w1[NNUE_SIZE * feature_w + i];
-        m_accumulator[1][i] += m_network.w1[NNUE_SIZE * feature_b + i];
+        m_accumulator[ply][0][i] += m_network.w1[NNUE_SIZE * feature_w + i];
+        m_accumulator[ply][1][i] += m_network.w1[NNUE_SIZE * feature_b + i];
     }
 }
 
-void NNUE::Inputs_RemovePiece(int color, int pieceType, int square) {
+void NNUE::Inputs_RemovePiece(int color, int pieceType, int square, int ply) {
     const int kingSquare_w = BitscanForward(m_pieces[WHITE][KING]);
     const int kingSquare_b = BitscanForward(m_pieces[BLACK][KING]) ^ NNUEConstants::BLACK_PERSPECTIVE_XOR;
 
@@ -175,12 +177,12 @@ void NNUE::Inputs_RemovePiece(int color, int pieceType, int square) {
     assert(feature_b <= NNUE_FEATURES);
 
     for(int i = 0; i < NNUE_SIZE; i++) {
-        m_accumulator[0][i] -= m_network.w1[NNUE_SIZE * feature_w + i];
-        m_accumulator[1][i] -= m_network.w1[NNUE_SIZE * feature_b + i];
+        m_accumulator[ply][0][i] -= m_network.w1[NNUE_SIZE * feature_w + i];
+        m_accumulator[ply][1][i] -= m_network.w1[NNUE_SIZE * feature_b + i];
     }
 }
 
-void NNUE::Inputs_MovePiece(int color, int pieceType, int fromSq, int toSq) {
+void NNUE::Inputs_MovePiece(int color, int pieceType, int fromSq, int toSq, int ply) {
     const int kingSquare_w = BitscanForward(m_pieces[WHITE][KING]);
     const int kingSquare_b = BitscanForward(m_pieces[BLACK][KING]) ^ NNUEConstants::BLACK_PERSPECTIVE_XOR;
 
@@ -209,12 +211,16 @@ void NNUE::Inputs_MovePiece(int color, int pieceType, int fromSq, int toSq) {
     assert(feature_to_b <= NNUE_FEATURES);
 
     for(int i = 0; i < NNUE_SIZE; i++) {
-        m_accumulator[0][i] -= m_network.w1[NNUE_SIZE * feature_from_w + i];
-        m_accumulator[1][i] -= m_network.w1[NNUE_SIZE * feature_from_b + i];
+        m_accumulator[ply][0][i] -= m_network.w1[NNUE_SIZE * feature_from_w + i];
+        m_accumulator[ply][1][i] -= m_network.w1[NNUE_SIZE * feature_from_b + i];
 
-        m_accumulator[0][i] += m_network.w1[NNUE_SIZE * feature_to_w + i];
-        m_accumulator[1][i] += m_network.w1[NNUE_SIZE * feature_to_b + i];
+        m_accumulator[ply][0][i] += m_network.w1[NNUE_SIZE * feature_to_w + i];
+        m_accumulator[ply][1][i] += m_network.w1[NNUE_SIZE * feature_to_b + i];
     }
+}
+
+void NNUE::CopyAccumulator(int fromPly, int toPly) {
+    std::memcpy(&m_accumulator[toPly], m_accumulator[fromPly], sizeof(m_accumulator[0]));
 }
 
 float NNUE::Clamp(float n) {

--- a/tests/test-Evaluation.cpp
+++ b/tests/test-Evaluation.cpp
@@ -6,7 +6,7 @@
 using namespace TestCommon;
 #include <gtest/gtest.h>
 
-TEST(NNUE, IncrementalMatchesFull) {
+TEST(NNUE, Incremental_vs_FullUpdate) {
     Board board;
     
     // Sequence covering all NNUE update paths:
@@ -24,9 +24,30 @@ TEST(NNUE, IncrementalMatchesFull) {
     board.MakeMove("e7e6");
     board.MakeMove("e1g1"); // castling
     
+    // Test MakeMove
     int evalIncremental = Evaluation::Evaluate(board);
-    nnue.Inputs_FullUpdate();
+    nnue.Inputs_FullUpdate(board.Ply());
     int evalFull = Evaluation::Evaluate(board);
-    
+    EXPECT_EQ(evalIncremental, evalFull);
+
+    // Test TakeMove
+    board.TakeMove();
+    evalIncremental = Evaluation::Evaluate(board);
+    nnue.Inputs_FullUpdate(board.Ply());
+    evalFull = Evaluation::Evaluate(board);
+    EXPECT_EQ(evalIncremental, evalFull);
+
+    // Test MakeNull
+    board.MakeNull();
+    evalIncremental = Evaluation::Evaluate(board);
+    nnue.Inputs_FullUpdate(board.Ply());
+    evalFull = Evaluation::Evaluate(board);
+    EXPECT_EQ(evalIncremental, evalFull);
+
+    // Test TakeNull
+    board.TakeNull();
+    evalIncremental = Evaluation::Evaluate(board);
+    nnue.Inputs_FullUpdate(board.Ply());
+    evalFull = Evaluation::Evaluate(board);
     EXPECT_EQ(evalIncremental, evalFull);
 }


### PR DESCRIPTION
Avoid unnecesary `memcpy` calls in `TakeMove` by creating an array of accumulators per ply.

```
bench 2956027

Elo   | 2.72 +- 10.82 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 2170 W: 725 L: 708 D: 737
Penta | [83, 244, 422, 245, 91]
```