### PR TITLE
bugfix: solve segfault when UCI command 'quit' is sent

### DIFF
--- a/include/Uci.h
+++ b/include/Uci.h
@@ -4,6 +4,7 @@
 #include "Search.h"
 
 #include <sstream>
+#include <thread>
 
 inline bool UCI_PONDER = false;
 inline bool UCI_CLASSICAL_EVAL = false;
@@ -25,4 +26,5 @@ private:
 
     Board m_board;
     Search m_search;
+    std::thread m_searchThread;
 };

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -866,7 +866,6 @@ bool Search::TimeOver() {
 void Search::AllocateLimits(Board &board, const Limits& limits) {
     m_limits = limits;
     m_nodes = 0;
-    m_clock.Start();
 
     // Defaults
     m_maxDepth = MAX_DEPTH;
@@ -887,10 +886,13 @@ void Search::AllocateLimits(Board &board, const Limits& limits) {
 
     int myTime   = (color == WHITE) ? limits.wtime : limits.btime;
     int yourTime = (color == WHITE) ? limits.btime : limits.wtime;
-
     int myInc    = (color == WHITE) ? limits.winc  : limits.binc;
 
-    m_allocatedTime = myTime / movesToGo + myInc;
+    // Move overhead to account for communication delays
+    const int timeOverhead = 50; //ms
+    const int myTimeSafe = std::max(0, myTime - timeOverhead);
+
+    m_allocatedTime = myTimeSafe / movesToGo + myInc;
 
     if(m_debugMode)
         std::cout << "info string TimeAllocation " <<  myTime << " " << yourTime << " " << m_allocatedTime << std::endl;

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -847,7 +847,7 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
 // Check if search should be stopped due to time limits.
 // Calculate every N nodes to avoid expensive time checks.
 bool Search::TimeOver() {
-    if(m_nodesTimeCheck > 5000) {
+    if(m_nodesTimeCheck > 1024) {
         m_nodesTimeCheck = 0;
         m_elapsedTime = ElapsedTime();
         if(m_elapsedTime > m_allocatedTime || m_elapsedTime > m_forcedTime)

--- a/src/Uci.cpp
+++ b/src/Uci.cpp
@@ -8,7 +8,6 @@
 
 #include <iostream>
 #include <string>
-#include <thread>
 #include <vector>
 #include <iomanip>
 
@@ -84,6 +83,13 @@ void Uci::Launch() {
         }
         else if(token == "quit" || token == "q") {
             std::cout << "info string quitting" << std::endl;
+
+            // Wait for the search to finish before exiting
+            m_search.Stop();
+            if(m_searchThread.joinable()) {
+                m_searchThread.join();
+            }
+
             break;
         }
         //Non-UCI commands
@@ -250,17 +256,24 @@ void Uci::Go(std::istringstream &stream) {
         else {
             std::string temp;
             stream >> temp;
+            
+            const uint defaultNodes = 200000;
             P("UNDEFINED GO STATMENT: " << temp << " -- (LOADING DEFAULT VALUES) -- ");
-            m_search.FixTime(2000);
+            P("Nodes: " << defaultNodes);
+            limits.nodes = defaultNodes;
             break;
         }
 
     }
 
+    // Wait thread of the previous search
+    if(m_searchThread.joinable()) {
+        m_searchThread.join();
+    }
+
     m_search.AllocateLimits(m_board, limits);
 
-    std::thread thread(&Uci::StartSearch, this);
-    thread.detach();
+    m_searchThread = std::thread(&Uci::StartSearch, this);
 }
 
 void Uci::Position(std::istringstream &stream) {


### PR DESCRIPTION
**Fix**: solve segfault when UCI command **'quit' is sent during the search**.

Example:
```
position fen 1K6/2P5/Ppp1B3/8/3P2P1/1P3b1k/2pn2p1/1qN5 w - - 0 1
go depth 25
quit
```
Error: `malloc(): unaligned fastbin chunk detected`
Happened because the "UCI" thread frees the memory while the "search" thread was finishing and still trying to access the global memory (hash tables, etc).

Solution: wait for the "search" thread to finish before exiting.

This PR also adds (great for ultrabullet):
- Checks time every **1024 nodes** (previously 5000).
- Introduces 50ms of **TIME_OVERHEAD** to account for GUI communication delays.

---

```
bench 2959687

Elo   | 30.29 +- 21.70 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.09 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 506 W: 195 L: 151 D: 160
Penta | [16, 37, 109, 69, 22]

Elo   | 6.37 +- 12.31 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1418 W: 462 L: 436 D: 520
Penta | [36, 158, 307, 160, 48]
```