### PR TITLE
enhance: eval cache to negamax

### DIFF
--- a/include/Constants.h
+++ b/include/Constants.h
@@ -27,6 +27,9 @@ constexpr i16 MATESCORE_MIN = MATESCORE_MAX - 1024;
 constexpr i16 TBWIN = MATESCORE_MIN - 1;
 constexpr i16 WINSCORE = TBWIN - 1024;
 
+constexpr i16 NO_SCORE = -INFINITE_I16;
+constexpr i16 NO_EVAL = -INFINITE_I16;
+
 constexpr int MAX_DEPTH = 128;
 constexpr int MAX_PLY = 256;
 constexpr int MAX_PLY_HISTORY = 2048;

--- a/include/Hash.h
+++ b/include/Hash.h
@@ -6,7 +6,7 @@
 constexpr uint DEFAULT_HASH_SIZE = 16; //In MegaBytes
 constexpr int PAWN_HASH_SIZE = 8192; //In number of entries
 
-// 2^19 entries = 2 MB / 32 bits per entry
+// 2^19 entries = 4 MB / 64 bits per entry
 constexpr u64 EVALCACHE_ENTRIES = 1 << 19;
 
 // =========================
@@ -58,10 +58,11 @@ private:
 // == Eval cache ==
 // ================
 
-// 16(zkey) + 16(eval) = 32 bits per entry
+// 32(zkey) + 16(eval) + 16(padding) = 64 bits per entry
 struct EvalEntry {
-    u16 zkey;
+    u32 zkey;
     i16 eval;
+    i16 padding;
 };
 
 class EvalCache {

--- a/include/Hash.h
+++ b/include/Hash.h
@@ -17,11 +17,12 @@ constexpr u64 EVALCACHE_ENTRIES = 1 << 19;
 // Beta node (from a fail-high): the true eval is at least equal to the score (truth >= score) LOWER_BOUND
 enum class TTENTRY_TYPE : u8 { NONE, EXACT, LOWER_BOUND, UPPER_BOUND };
 
-// 32(zkey) + 32(move) + 16(score) + 8(depth) + 2(type) + 6(age) + 32(padding) = 128 bits per entry
+// 32(zkey) + 32(move) + 16(score) + 8(depth) + 2(type) + 6(age) + 16(eval) + 16(padding) = 128 bits per entry
 struct TTEntry {
     u32 zkey;
-    u32 padding;
     i16 score;
+    i16 eval;
+    i16 padding;
     u8 depth;
     TTENTRY_TYPE type : 2;
     u8 age : 6;
@@ -35,7 +36,7 @@ public:
     TT();
     ~TT();
 
-    void Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth, int ply, int age);
+    void Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth, int ply, int age, int eval = NO_EVAL);
     TTEntry* Probe(u64 zkey, int depth);
 
     void Clear();

--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -132,7 +132,7 @@ void EvalCache::Store(u64 zkey, int eval) {
     EvalEntry& entry = m_evalEntries[index];
 
     // Always-replace strategy
-    entry.zkey = UpperBits<u16>(zkey);
+    entry.zkey = UpperBits<u32>(zkey);
     entry.eval = SafeCastInt16(eval);
 }
 
@@ -140,7 +140,7 @@ bool EvalCache::Probe(u64 zkey, int& eval) {
     u64 index = zkey & m_mask;
     EvalEntry& entry = m_evalEntries[index];
 
-    if(entry.zkey == UpperBits<u16>(zkey)) {
+    if(entry.zkey == UpperBits<u32>(zkey)) {
         eval = entry.eval;
         return true;
     }

--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -10,7 +10,9 @@
 
 void TTEntry::Clear() {
     zkey = 0;
-    score = 0;
+    score = NO_SCORE;
+    eval = NO_EVAL;
+    padding = 0;
     depth = 0;
     type = TTENTRY_TYPE::NONE;
     age = 0;
@@ -26,7 +28,7 @@ TT::~TT() {
     delete [] m_entries;
 }
 
-void TT::Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth, int ply, int age) {
+void TT::Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth, int ply, int age, int eval) {
     assert(abs(score) <= MATESCORE_MAX);
     assert(depth <= MAX_DEPTH);
 
@@ -36,9 +38,12 @@ void TT::Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth,
     //Replacement scheme
     const bool older = age != entry-> age;
     const bool higherDepth = depth >= entry->depth;
-    if(older || higherDepth) {
+
+    const bool replace = older || higherDepth;
+    if(replace) {
         entry->zkey = UpperBits<u32>(zkey);
         entry->score = SafeCastInt16( ScoreToHash(score, ply) );
+        entry->eval = SafeCastInt16(eval);
         entry->depth = SafeCastU8(depth);
         entry->type = type;
         entry->age = age;

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -437,11 +437,15 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
     Move bestMove; // For later storage in the TT
     int bestScore = -INFINITE_SCORE;
     int alphaOriginal = alpha; // For TT entry type calculation
+    int ttEval = NO_EVAL;
     
     TTEntry* ttEntry = Hash::tt.Probe(board.ZKey(), depth);
     if(ttEntry && !isPV) {
         D( m_debug.Increment("NegaMax: TT Hit") );
+
         int score = Hash::tt.ScoreFromHash(ttEntry->score, m_ply);
+        ttEval = ttEntry->eval;
+
         if( ttEntry->type == TTENTRY_TYPE::EXACT
             || (ttEntry->type == TTENTRY_TYPE::UPPER_BOUND && score <= alpha)
             || (ttEntry->type == TTENTRY_TYPE::LOWER_BOUND && score >= beta)
@@ -490,8 +494,19 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
     // Calculate static evaluation once, used for pruning heuristics
     int eval = 0;
     if(!inCheck) {
-        D( m_debug.Increment("NegaMax: _: Call to Evaluation") );
-        eval = Evaluation::Evaluate(board);
+        D( m_debug.Increment("NegaMax: Evaluation: 1: Enter") );
+        if(ttEval != NO_EVAL) {
+            D( m_debug.Increment("NegaMax: Evaluation: 2.1: Use TT Eval") );
+            eval = ttEval;
+        }
+        else if(Hash::evalCache.Probe(board.ZKey(), eval)) {
+            D( m_debug.Increment("NegaMax: Evaluation: 2.2: Use EvalCache") );
+        }
+        else {
+            D( m_debug.Increment("NegaMax: Evaluation: 3: Call Evaluate()") );
+            eval = Evaluation::Evaluate(board);
+            Hash::evalCache.Store(board.ZKey(), eval);
+        }
     }
 
     // --- Reverse Futility Pruning ---
@@ -546,7 +561,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
             D( m_debug.Increment("NegaMax: Pruning: NullMove: Beta Cutoff - Depth " + std::to_string(depth)) );
             if(IsWinValue(nullScore))
                 nullScore = beta;  // Avoid reporting false mates in zugzwang
-            Hash::tt.Store(board.ZKey(), nullScore, TTENTRY_TYPE::LOWER_BOUND, Move(), nullDepth, m_ply, m_searchCount);
+            Hash::tt.Store(board.ZKey(), nullScore, TTENTRY_TYPE::LOWER_BOUND, Move(), nullDepth, m_ply, m_searchCount, eval);
             return nullScore;
         }
     }
@@ -670,7 +685,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
         if(score >= beta) {
             D( m_debug.Increment("NegaMax: AlphaBeta: Beta Cutoff (score >= beta)") );
 
-            Hash::tt.Store(board.ZKey(), score, TTENTRY_TYPE::LOWER_BOUND, move, depth, m_ply, m_searchCount);
+            Hash::tt.Store(board.ZKey(), score, TTENTRY_TYPE::LOWER_BOUND, move, depth, m_ply, m_searchCount, eval);
 
             // Update heuristics
             if( move.IsQuiet() ) {
@@ -696,7 +711,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
         D( m_debug.Increment("NegaMax: AlphaBeta: " + std::string(withinBounds ? "Exact" : "UpperBound")) );
         TTENTRY_TYPE type = withinBounds ? TTENTRY_TYPE::EXACT
                                          : TTENTRY_TYPE::UPPER_BOUND;
-        Hash::tt.Store(board.ZKey(), bestScore, type, bestMove, depth, m_ply, m_searchCount);
+        Hash::tt.Store(board.ZKey(), bestScore, type, bestMove, depth, m_ply, m_searchCount, eval);
     }
 
     return bestScore;

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -78,7 +78,7 @@ Search::Search() {
     m_forcedNodes = INFINITE_U64;
 
     // Search state
-    m_bestScore = -INFINITE_SCORE;
+    m_bestScore = NO_SCORE;
     m_searchCount = 0;
 
     ClearSearch(true);
@@ -108,7 +108,7 @@ void Search::ClearSearch(bool fullClear) {
 
     // Search state
     m_pv.ClearTable();
-    m_bestScore = -INFINITE_SCORE;
+    m_bestScore = NO_SCORE;
     m_bestMove = Move();
 
     // Depth tracking
@@ -275,7 +275,7 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
     m_nodes++;
 
     Move bestMove;
-    int bestScore = -INFINITE_SCORE;
+    int bestScore = NO_SCORE;
     int alphaOriginal = alpha; // Save the original alpha for TT logic
     int score;
 
@@ -435,7 +435,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
 
     // --------- Transposition table probe --------
     Move bestMove; // For later storage in the TT
-    int bestScore = -INFINITE_SCORE;
+    int bestScore = NO_SCORE;
     int alphaOriginal = alpha; // For TT entry type calculation
     int ttEval = NO_EVAL;
     
@@ -491,18 +491,17 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
         }
     }
 
-    // Calculate static evaluation once, used for pruning heuristics
+    // --------- Static Evaluation ---------
+    // Used in pruning heuristics
     int eval = 0;
     if(!inCheck) {
         D( m_debug.Increment("NegaMax: Evaluation: 1: Enter") );
         if(ttEval != NO_EVAL) {
             D( m_debug.Increment("NegaMax: Evaluation: 2.1: Use TT Eval") );
             eval = ttEval;
-        }
-        else if(Hash::evalCache.Probe(board.ZKey(), eval)) {
+        } else if(Hash::evalCache.Probe(board.ZKey(), eval)) {
             D( m_debug.Increment("NegaMax: Evaluation: 2.2: Use EvalCache") );
-        }
-        else {
+        } else {
             D( m_debug.Increment("NegaMax: Evaluation: 3: Call Evaluate()") );
             eval = Evaluation::Evaluate(board);
             Hash::evalCache.Store(board.ZKey(), eval);
@@ -741,14 +740,17 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
         return Evaluation::Evaluate(board);
     }
 
+    const bool isPV = (beta - alpha) != 1;
+    Move hashMove; // For move ordering
+    int ttEval = NO_EVAL;
+
     // Probe transposition table.
     // Only non-PV nodes: PV nodes require the most accurate score possible.
     TTEntry* ttEntry = Hash::tt.Probe(board.ZKey(), 0);
-    Move hashMove; // For move ordering
-    const bool isPV = (beta - alpha) != 1;
     if(ttEntry) {
         D( m_debug.Increment("Quiescence: TT Hit: Exists") );
         hashMove = ttEntry->bestMove;
+        ttEval = ttEntry->eval;
 
         if(!isPV) {
             int score = Hash::tt.ScoreFromHash(ttEntry->score, m_ply);
@@ -762,17 +764,21 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
         }
     }
 
-    // Stand pat: static evaluation of current position
-    int standPat = 0;
-    int bestScore = -INFINITE_SCORE;
     bool inCheck = board.IsCheck();
+    int bestScore = NO_SCORE;
+
+    // Stand pat: static evaluation of current position
+    // Probe evaluation cache first (modifies standPat if hit)
+    int standPat = 0;
     if(!inCheck) {
-        // Probe evaluation cache first (modifies standPat if hit)
-        const bool cacheHit = Hash::evalCache.Probe(board.ZKey(), standPat);
-        if(cacheHit) {
-            D( m_debug.Increment("Quiescence: StandPat: EvalCache hit") );
+        D( m_debug.Increment("Quiescence: Evaluation: 1: Enter") );
+        if(ttEval != NO_EVAL) {
+            D( m_debug.Increment("Quiescence: Evaluation: 2.1: Use TT Eval") );
+            standPat = ttEval;
+        } else if(Hash::evalCache.Probe(board.ZKey(), standPat)) {
+            D( m_debug.Increment("Quiescence: Evaluation: 2.2: Use EvalCache") );
         } else {
-            D( m_debug.Increment("Quiescence: StandPat: Evaluation called") );
+            D( m_debug.Increment("Quiescence: Evaluation: 3: Call Evaluate()") );
             standPat = Evaluation::Evaluate(board);
             Hash::evalCache.Store(board.ZKey(), standPat);
         }
@@ -848,7 +854,7 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
             bestScore = score;
 
         if(score >= beta) {
-            Hash::tt.Store(board.ZKey(), bestScore, TTENTRY_TYPE::LOWER_BOUND, move, 0, m_ply, m_searchCount);
+            Hash::tt.Store(board.ZKey(), bestScore, TTENTRY_TYPE::LOWER_BOUND, move, 0, m_ply, m_searchCount, standPat);
             return score;
         }
 


### PR DESCRIPTION
**Enhance: Optimize eval cache system**

- Store the `ttEval` in the Hash table (use 16 bits of the 32-bit padding).
  - Use the `ttEval` in NegaMax and Quiescence if available.
- Use and store EvalCache in NegaMax (prevously only used in Quiescence).
  - In EvalCache, increase the zkey to 32 bits (previously 16 bits) to reduce collisions.

```
bench 2959622 (previous: 2959687)

Elo   | 11.00 +- 9.14 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-2.00, 8.00]
Games | N: 2938 W: 1001 L: 908 D: 1029
Penta | [93, 320, 588, 337, 131]

Elo   | 9.31 +- 8.09 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [-2.00, 8.00]
Games | N: 3470 W: 1103 L: 1010 D: 1357
Penta | [94, 402, 674, 447, 118]
```