### PR TITLE
refactor: search limits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ set(ENGINE_SOURCES
     src/NNUE.cpp
     src/PV.cpp
     src/Search.cpp
+    src/SearchLimits.cpp
     src/Syzygy.cpp
     src/Uci.cpp
     src/Utils.cpp

--- a/Main.cpp
+++ b/Main.cpp
@@ -64,10 +64,8 @@ int main(int argc, char** argv) {
     Uci uci;
     uci.Launch();
 
-    int64_t elapsed = clock.Elapsed();
-    std::cout << "info string [TIME] Init " << elapsed << " ms" << std::endl;
+    std::cout << "info string [TIME] " << clock.Elapsed() << " ms" << std::endl;
 
     Syzygy::Free();
-
     return 0;
 }

--- a/include/Constants.h
+++ b/include/Constants.h
@@ -18,8 +18,9 @@ using u64 = uint64_t;
 using Bitboard = uint64_t;
 
 constexpr int INFINITE = std::numeric_limits<int>::max();
-constexpr u64 INFINITE_U64 = std::numeric_limits<u64>::max();
 constexpr i16 INFINITE_I16 = std::numeric_limits<i16>::max();
+constexpr i64 INFINITE_I64 = std::numeric_limits<i64>::max();
+constexpr u64 INFINITE_U64 = std::numeric_limits<u64>::max();
 
 constexpr i16 INFINITE_SCORE = INFINITE_I16 - 1024;
 constexpr i16 MATESCORE_MAX = INFINITE_SCORE - 1024;

--- a/include/PV.h
+++ b/include/PV.h
@@ -14,7 +14,7 @@ public:
 
     void Update(int ply, Move move);
 
-    Move PonderMove() const;
+    std::string PonderString() const;
     std::string PVString() const;
 
 private:

--- a/include/Search.h
+++ b/include/Search.h
@@ -7,6 +7,7 @@
 #include "Heuristics.h"
 #include "Move.h"
 #include "PV.h"
+#include "SearchLimits.h"
 #include "Utils.h"
 
 #include <vector>
@@ -15,49 +16,25 @@ const int MAX_ROOTMOVES = 256;
 
 using BOUND_TYPE = TTENTRY_TYPE;
 
-// Search limits from UCI
-struct Limits {
-    bool infinite = false;
-    bool ponderhit = false;
-    int depth = 0;
-    int nodes = 0;
-    int moveTime = 0;
-
-    int wtime = 0;
-    int btime = 0;
-
-    int winc = 0;
-    int binc = 0;
-
-    int movesToGo = 0;
-};
-
 class Search {
 public:
     Search();
+    void ClearSearch(bool fullSearchClearFlag);
 
     // Start search
-    void IterativeDeepening(Board &board, bool fullSearchClearFlag = false);
+    void IterativeDeepening(Board &board, const UCI_Limits& limits, bool fullSearchClearFlag = false);
 
     // Flow
-    void ClearSearch(bool fullSearchClearFlag);
-    int64_t ElapsedTime() { return m_clock.Elapsed(); }
-    void Stop() { m_stop = true; }
-    void DebugMode() { m_debugMode = true; }
+    void PonderHit() { m_limits.PonderHit(); }
+    void Stop() { m_limits.Stop(); }
 
     // Limits management
-    Limits GetLimits() { return m_limits; }
-    void AllocateLimits(Board &board, const Limits& limits);
-    void FixDepth(int depth);
-    void FixTime(int time); // (ms)
-    void FixNodes(int nodes);
-    void Infinite();
+    const Limits& GetLimits() const { return m_limits; }
 
     // Getters
     Move BestMove() const { return m_bestMove; };
     int BestScore() const { return m_bestScore; };
     u64 GetNodes() const { return m_nodes; };
-    int GetNps() const { return m_nps; };
 
     // Interface
     void MakeMove(Board &board) { board.MakeMove(m_bestMove); };
@@ -69,16 +46,8 @@ private:
     int NegaMax(Board  &board, int depth, int alpha, int beta);
     int QuiescenceSearch(Board &board, int alpha, int beta);
 
-    // IterativeDeepening methods
-    void UciOutput(std::string PV, int score, BOUND_TYPE bound = BOUND_TYPE::EXACT);
-
     // NegaMax methods
     int LateMoveReductions(int moveScore, int depth, int moveNumber, bool isPV);
-
-    // Limits and internal calculations
-    int CalculateNPS() { return static_cast<int>(1000 * m_nodes / (m_elapsedTime+1)); }
-    bool TimeOver();
-    bool NodeLimit() { return m_nodes >= m_forcedNodes; };
 
     // Debug
     void ShowDebugInfo();
@@ -93,7 +62,6 @@ private:
     u8 m_searchCount; // Used as 'age' in transposition tables
     // Nodes
     u64 m_nodes; // Number of nodes searched
-    int m_nps; // Nodes per second
     uint m_tbHits; // Number of endgame table hits
     // Depth
     int m_depth; // Current search depth, in plies, for this iteration
@@ -103,21 +71,10 @@ private:
 
     // Limits
     Limits m_limits;
-    int m_maxDepth; // Fixed depth limit
-    int m_forcedTime; // Fixed time limit (ms)
-    u64 m_forcedNodes; // Fixed nodes limit
-    bool m_stop; // Flag to indicate search stop
-    
-    // Time management
-    Utils::Clock m_clock;
-    int64_t m_elapsedTime; // Time passed since the start of the search (ms)
-    int m_allocatedTime; // In normal timed games, estimation of the time to use within the search (ms)
-    int m_nodesTimeCheck; // Number of nodes searched since the last time check
 
     // Heuristics
     Heuristics m_heuristics; // Heuristics for move ordering (history, killers)
 
     // Debug
-    bool m_debugMode; // UCI debug mode
     SearchDebug m_debug;
 };

--- a/include/SearchLimits.h
+++ b/include/SearchLimits.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "Constants.h"
+#include "Utils.h"
+
+#include <atomic>
+
+// Search limits from UCI (input)
+struct UCI_Limits {
+    bool infinite = false;
+
+    bool ponder = false;
+    bool ponderhit = false;
+
+    int depth = 0;
+    int nodes = 0;
+    int moveTime = 0;
+
+    int wtime = 0;
+    int btime = 0;
+
+    int winc = 0;
+    int binc = 0;
+
+    int movesToGo = 0;
+
+    static UCI_Limits FixDepth(int depth) { return UCI_Limits{ .depth = depth }; };
+    static UCI_Limits FixTime(int time) { return UCI_Limits{ .moveTime = time }; };
+    static UCI_Limits FixNodes(int nodes) { return UCI_Limits{ .nodes = nodes }; };
+    static UCI_Limits Infinite() { return UCI_Limits{ .infinite = true }; };
+};
+
+// Management of search limits (transformed)
+class Limits {
+public:
+    Limits() = default;
+
+    void StartNewSearch(COLOR color, const UCI_Limits& limits);
+
+    bool LimitsReached(u64 nodes);
+
+    // Time management
+    i64 UpdateElapsedTime();
+    uint CalculateNPS(u64 nodes) const;
+
+    // UCI signals
+    void ResetSignals();
+    void PonderHit() { m_ponderhit = true; }
+    void Stop() { m_stop = true; }
+
+    // Getters
+    i64 AllocatedTime() const { return m_allocatedTime; }
+    i64 ElapsedTime() const { return m_elapsedTime; }
+    int MaxDepth() const { return m_forcedDepth; }
+    bool Stopped() const { return m_stop; }
+    
+private:
+    // =============
+    // == Methods ==
+    // =============
+    void AllocateLimits(COLOR color, const UCI_Limits& limits);
+
+    void Infinite();
+    
+    void Apply_PonderHit();
+    void RestartClock();
+
+    // ===============
+    // == Variables ==
+    // ===============
+    UCI_Limits m_limits;
+
+    COLOR m_color;
+
+    // Time management
+    Utils::Clock m_clock;
+    i64 m_elapsedTime = 0; // Time passed since the start of the search (ms)
+    i64 m_allocatedTime = 0; // In normal timed games, estimation of the time to use within the search (ms)
+    u64 m_nextTimeCheck = 0; // Next node count to check time (to avoid expensive time checks every node)
+
+    // Fixed limits
+    int m_forcedDepth = 0; // Fixed depth limit
+    i64 m_forcedTime = 0; // Fixed time limit (ms)
+    u64 m_forcedNodes = 0; // Fixed nodes limit
+
+    std::atomic<bool> m_stop = false; // Flag to stop the search (time limit, user input, etc.)
+    std::atomic<bool> m_ponderhit = false; // Flag to indicate that the ponder move was played
+};

--- a/include/Uci.h
+++ b/include/Uci.h
@@ -12,17 +12,25 @@ inline uint UCI_SYZYGY_PROBE_LIMIT = 7;
 
 inline bool UCI_OUTPUT = true;
 
+constexpr int UCI_OUTPUT_ROOTMAX_MINTIME = 1000; //ms
+
 class Uci {
 public:
     Uci();
     void Bench(int depth, bool verbose);
     void Launch();
 
+    // Search Outputs
+    static void Output(int depth, int seldepth, int score, u64 nodes, i64 time, uint nps, int tbHits, BOUND_TYPE bound, const std::string& PV);
+    static void RootUpdate(int depth, int seldepth, int currMoveNumber, const std::string& currMove, u64 nodes, i64 time, uint nps, int tbHits);
+    static void BestMove(const std::string& bestMove, const std::string& ponderMove);
+
 private:
     void Go(std::istringstream &stream);
     void Position(std::istringstream &stream);
     void SetOption(std::istringstream &stream);
-    void StartSearch();
+    void StartSearch(UCI_Limits limits);
+    void StopAndJoin();
 
     Board m_board;
     Search m_search;

--- a/include/Uci.h
+++ b/include/Uci.h
@@ -2,6 +2,7 @@
 
 #include "Board.h"
 #include "Search.h"
+#include "SearchLimits.h"
 
 #include <sstream>
 #include <thread>
@@ -17,6 +18,7 @@ constexpr int UCI_OUTPUT_ROOTMAX_MINTIME = 1000; //ms
 class Uci {
 public:
     Uci();
+    ~Uci();
     void Bench(int depth, bool verbose);
     void Launch();
 
@@ -29,10 +31,11 @@ private:
     void Go(std::istringstream &stream);
     void Position(std::istringstream &stream);
     void SetOption(std::istringstream &stream);
-    void StartSearch(UCI_Limits limits);
+    void StartSearch();
     void StopAndJoin();
 
     Board m_board;
     Search m_search;
+    UCI_Limits m_limits;
     std::thread m_searchThread;
 };

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -31,8 +31,8 @@ namespace Utils {
     class Clock {
     public:
         void Start();
-        int64_t Elapsed();
-        int64_t ElapsedNanoseconds();
+        int64_t Elapsed() const;
+        int64_t ElapsedNanoseconds() const;
     private:
         std::chrono::high_resolution_clock::time_point m_start;
     };

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -65,8 +65,8 @@ void Interface::Start(std::string fenString) {
         //Think and make a move
         else if(input == "think" || input == "t") {
             Search search;
-            search.FixDepth(11);
-            search.IterativeDeepening(m_board);
+
+            search.IterativeDeepening(m_board, UCI_Limits::FixDepth(11));
             search.MakeMove(m_board);
         }
 

--- a/src/NNUE.cpp
+++ b/src/NNUE.cpp
@@ -74,14 +74,14 @@ bool NNUE::Load(std::string filepath) {
 
 int NNUE::Evaluate(int color, int ply) const {
     //Layer 1
-    alignas(32) i16 outputLayer1[NNUE_SIZE * 2];
+    i16 outputLayer1[NNUE_SIZE * 2];
 
     ActivateReLU(m_accumulator[ply][color], outputLayer1, NNUE_SIZE);
     ActivateReLU(m_accumulator[ply][1-color], outputLayer1 + NNUE_SIZE, NNUE_SIZE);
 
     //Layers 2,3,4
-    alignas(32) i16 o2[ ARCH[L3][ROW] ];
-    alignas(32) i16 o3[ ARCH[L4][ROW] ];
+    i16 o2[ ARCH[L3][ROW] ];
+    i16 o3[ ARCH[L4][ROW] ];
     i32 o4[1];
 
     ComputeLayer<i16, true>(outputLayer1, o2, m_network.b2, m_network.w2, ARCH[L2][ROW], ARCH[L2][COL]);

--- a/src/PV.cpp
+++ b/src/PV.cpp
@@ -27,10 +27,10 @@ void PV::Update(int ply, Move move) {
     m_pvLength[ply] = m_pvLength[childPly] + 1;
 }
 
-Move PV::PonderMove() const {
-    if(m_pvLength[0] > 1)
-        return m_pvTable[0][1];
-    return Move();
+std::string PV::PonderString() const {
+    if(m_pvLength[0] > 1 && m_pvTable[0][1].MoveType() != NULLMOVE)
+        return m_pvTable[0][1].Notation();
+    return "";
 }
 
 std::string PV::PVString() const {

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -61,8 +61,6 @@ const int NULLMOVE_REDUCTION_FACTOR = 3;
 const bool TURNOFF_LMR = false;
 const bool TURNOFF_FUTILITY = false;
 
-const int UCI_OUTPUT_ROOTMAX_MINTIME = 1000; //ms
-
 // Draw contempt to discourage premature draws
 constexpr int DrawScore(int ply) {
     return (ply & 1) ? 10 : -10;
@@ -70,26 +68,9 @@ constexpr int DrawScore(int ply) {
 
 // Called once when the UCI interface starts up.
 Search::Search() {
-    // Limits and time management
-    m_maxDepth = MAX_DEPTH;
-    m_allocatedTime = 3500; //ms
-    m_forcedTime = INFINITE;
-    m_forcedNodes = INFINITE_U64;
-
-    // Search state
-    m_bestScore = NO_SCORE;
-    m_searchCount = 0;
-
     ClearSearch(true);
-    m_heuristics.history.Clear();
 
-    // Clear transposition tables
-    Hash::tt.Clear();
-    Hash::evalCache.Clear();
-    Hash::pawnHash.Clear();
-
-    // Debug
-    m_debugMode = false;
+    m_searchCount = 0;
 }
 
 // Reset state for a new position search.
@@ -97,13 +78,7 @@ Search::Search() {
 void Search::ClearSearch(bool fullClear) {
     // Node counters
     m_nodes = 0;
-    m_nps = 0;
     m_tbHits = 0;
-
-    // Time management
-    m_elapsedTime = 0;
-    m_stop = false;
-    m_nodesTimeCheck = 0;
 
     // Search state
     m_pv.ClearTable();
@@ -137,15 +112,15 @@ void Search::ClearSearch(bool fullClear) {
 
 // Main loop: increase depth one by one and call the root search.
 // Manage time, aspiration window, and UCI output.
-void Search::IterativeDeepening(Board &board, bool fullClear) {
-    m_clock.Start();
-
+void Search::IterativeDeepening(Board &board, const UCI_Limits& limits, bool fullClear) {
     ClearSearch(fullClear);
+
+    m_limits.StartNewSearch(board.ActivePlayer(), limits);
     
     D( m_debug.Increment("IterativeDeepening: _: Start") );
     m_searchCount++;
 
-    for(m_depth = 1; m_depth <= m_maxDepth; m_depth++) {
+    for(m_depth = 1; m_depth <= m_limits.MaxDepth(); m_depth++) {
         assert(m_ply == 0);
         assert(m_plyqs == 0);
         assert(m_nullmoveAllowed);
@@ -155,73 +130,21 @@ void Search::IterativeDeepening(Board &board, bool fullClear) {
         AspirationWindow(board, m_depth, m_bestScore);
 
         // Stop search if limits are reached within the loop
-        if(m_stop) break;
+        if(m_limits.Stopped()) break;
 
-        // PV
-        UciOutput(m_pv.PVString(), m_bestScore);
+        i64 elapsedTime = m_limits.UpdateElapsedTime();
+        Uci::Output(m_depth, m_selPly, m_bestScore, m_nodes, elapsedTime, m_limits.CalculateNPS(m_nodes), m_tbHits, BOUND_TYPE::EXACT, m_pv.PVString());
 
         // Stop search if we used half of the allocated time, since
         // next iteration will likely use more than the allocated time
-        if(m_elapsedTime > (m_allocatedTime / 2)) //check
+        if(elapsedTime > (m_limits.AllocatedTime() / 2))
             break;
 
-        if(DEBUG_PRINT_STATISTICS && m_depth == m_maxDepth)
+        if(DEBUG_PRINT_STATISTICS && m_depth == m_limits.MaxDepth())
             D( m_debug.Print() );
     }
 
-    if(UCI_OUTPUT) {
-        std::cout << "bestmove " << m_bestMove.Notation();
-        if(UCI_PONDER)
-            std::cout << " ponder " << m_pv.PonderMove().Notation();
-        std::cout << std::endl;
-    }
-}
-
-void Search::UciOutput(std::string PV, int score, BOUND_TYPE bound) {
-    m_elapsedTime = ElapsedTime();
-    m_nps = CalculateNPS();
-
-    if(!UCI_OUTPUT) return;
-
-    std::cout << "info depth " << m_depth;
-    std::cout << " seldepth " << m_selPly;
-
-    if(IsMateValue(score)) {
-        int mateScore = (score > 0) ?  MATESCORE_MAX - score + 1
-                                    : -MATESCORE_MAX - score - 1;
-        std::cout << " score mate " << mateScore / 2; //return mate in moves, not in plies
-    } else {
-        std::cout << " score cp " << score;
-    }
-    if(bound == BOUND_TYPE::LOWER_BOUND) std::cout << " lowerbound";
-    if(bound == BOUND_TYPE::UPPER_BOUND) std::cout << " upperbound";
-
-    std::cout << " time " << m_elapsedTime;
-    std::cout << " nodes " << m_nodes;
-    std::cout << " nps " << m_nps;
-    if(m_elapsedTime > 1000)
-        std::cout << " hashfull " << Hash::tt.Occupancy();
-    if(m_tbHits)
-        std::cout << " tbhits " << m_tbHits;
-    std::cout << " pv " << PV;
-    std::cout << std::endl;
-}
-
-//Set limits
-void Search::FixDepth(int depth) {
-    m_allocatedTime = INFINITE;
-    m_maxDepth = depth;
-}
-void Search::FixTime(int time) {
-    m_allocatedTime = INFINITE;
-    m_forcedTime = time;
-}
-void Search::FixNodes(int nodes) {
-    m_allocatedTime = INFINITE;
-    m_forcedNodes = nodes;
-}
-void Search::Infinite() {
-    m_allocatedTime = INFINITE;
+    Uci::BestMove(m_bestMove.Notation(), m_pv.PonderString());
 }
 
 // Narrow alpha-beta bounds around expected score
@@ -236,13 +159,14 @@ int Search::AspirationWindow(Board& board, const int depth, const int bestScore)
 
     int score = RootMax(board, depth, alpha, beta);
 
-    for(int researches = 1; !m_stop && (score <= alpha || score >= beta); researches++) {
+    for(int researches = 1; !m_limits.Stopped() && (score <= alpha || score >= beta); researches++) {
         D( m_debug.Increment("AspirationWindow: Out of bounds: Researches: " + std::to_string(researches) ); );
 
         // Display lowerbound / upperbound info
         BOUND_TYPE bound = (score <= alpha) ? BOUND_TYPE::UPPER_BOUND
                                             : BOUND_TYPE::LOWER_BOUND;
-        UciOutput(m_bestMove.Notation(), score, bound);
+        i64 elapsedTime = m_limits.UpdateElapsedTime();
+        Uci::Output(m_depth, m_selPly, score, m_nodes, elapsedTime, m_limits.CalculateNPS(m_nodes), m_tbHits, bound, m_pv.PVString());
 
         // Asymmetrical incremental aspiration
         window = window * ASPIRATION_WINDOW_MULTIPLIER;
@@ -277,6 +201,7 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
     int bestScore = NO_SCORE;
     int alphaOriginal = alpha; // Save the original alpha for TT logic
     int score;
+    i64 elapsedTime;
 
     m_pv.ClearPly(m_ply);
 
@@ -298,21 +223,8 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
             P( "RootMax: " << move.Notation() );
 
         // Display the root move under analysis and update the counters
-        if(UCI_OUTPUT && m_elapsedTime > UCI_OUTPUT_ROOTMAX_MINTIME) {
-            m_elapsedTime = ElapsedTime();
-            m_nps = CalculateNPS();
-
-            std::cout << "info depth " << m_depth
-                      << " seldepth " << m_selPly
-                      << " currmovenumber " << moveNumber
-                      << " currmove " << move.Notation()
-                      << " time " << m_elapsedTime
-                      << " nodes " << m_nodes
-                      << " nps " << m_nps;
-            if(m_tbHits)
-                std::cout << " tbhits " << m_tbHits;
-            std::cout << std::endl;
-        }
+        elapsedTime = m_limits.UpdateElapsedTime();
+        Uci::RootUpdate(m_depth, m_selPly, moveNumber, move.Notation(), m_nodes, elapsedTime, m_limits.CalculateNPS(m_nodes), m_tbHits);
 
         board.MakeMove(move);
         m_ply++;
@@ -333,7 +245,7 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
         board.TakeMove(move);
         m_ply--;
 
-        if(m_stop) break;
+        if(m_limits.Stopped()) break;
 
         if(score > bestScore) {
             D( m_debug.Increment("RootMax: AlphaBeta: Update BestMove (score > bestScore)") );
@@ -358,14 +270,17 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
 
             m_pv.Update(m_ply, move);
 
-            if(m_elapsedTime > UCI_OUTPUT_ROOTMAX_MINTIME)
-                UciOutput(m_pv.PVString(), score, BOUND_TYPE::LOWER_BOUND);
+            elapsedTime = m_limits.ElapsedTime();
+            if(elapsedTime > UCI_OUTPUT_ROOTMAX_MINTIME) {
+                elapsedTime = m_limits.UpdateElapsedTime();
+                Uci::Output(m_depth, m_selPly, score, m_nodes, elapsedTime, m_limits.CalculateNPS(m_nodes), m_tbHits, BOUND_TYPE::LOWER_BOUND, m_pv.PVString());
+            }
         }
     }
 
     // Store "exact" score in transposition table if search finished within search bounds
     bool withinBounds = (bestScore > alphaOriginal) && (bestScore < beta);
-    if(!m_stop && withinBounds) {
+    if(!m_limits.Stopped() && withinBounds) {
         assert(bestMove == m_bestMove && bestScore == m_bestScore);
         D( m_debug.Increment("RootMax: AlphaBeta: TT Store Exact") );
 
@@ -379,22 +294,25 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
 // Implements most of the engine's search logic.
 int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
     assert(alpha >= -INFINITE_SCORE && beta <= INFINITE_SCORE && alpha < beta);
-    assert(m_ply < MAX_PLY);
 
     D( m_debug.Increment("NegaMax: _: Entering function") );
 
     m_nodes++;
-    m_nodesTimeCheck++;
+
+    //---------- Safety net -------------
+    // Prevents the search from going too deep and crashing the engine
+    if(m_ply >= MAX_PLY-1) {
+        D( m_debug.Increment("NegaMax: Safety: MAX_PLY reached") );
+        return Evaluation::Evaluate(board);
+    }
 
     const bool isPV = (beta - alpha) != 1;
     if(isPV)
         m_pv.ClearPly(m_ply);
 
     // --------- Termination checks -----------
-    if( m_stop || NodeLimit() || TimeOver() ) {
-        m_stop = true;
+    if(m_limits.LimitsReached(m_nodes))
         return 0;
-    }
 
     // --------- Draw detection: repetition and 50-move rule -----------
     if(board.FiftyRule() >= 100) {
@@ -672,7 +590,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
         board.TakeMove(move);
         m_ply--;
 
-        if(m_stop) return 0;
+        if(m_limits.Stopped()) return 0;
 
         if(score > bestScore) {
             D( m_debug.Increment("NegaMax: AlphaBeta: Update BestMove (score > bestScore)") );
@@ -725,13 +643,10 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
     D( if(m_plyqs <= 2 || m_plyqs % 5 == 0) m_debug.Increment("Quiescence: QPly " + std::to_string(m_plyqs)) );
 
     m_nodes++;
-    m_nodesTimeCheck++;
 
     // Termination checks
-    if( m_stop || NodeLimit() || TimeOver() ) {
-        m_stop = true;
+    if(m_limits.LimitsReached(m_nodes))
         return 0;
-    }
 
     // Prevent infinite recursion in rare cases (unlikely to occur)
     if (m_plyqs >= MAX_QS_PLIES) {
@@ -844,7 +759,7 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
         board.TakeMove(move);
         m_ply--; m_plyqs--;
 
-        if(m_stop) return 0;
+        if(m_limits.Stopped()) return 0;
 
         D( BoardIdentity aft = BoardIntegrityChecker::GenerateBoardIdentity(board); );
         D( assert(bef == aft) );
@@ -862,60 +777,6 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
     }
 
     return bestScore;
-}
-
-// Check if search should be stopped due to time limits.
-// Calculate every N nodes to avoid expensive time checks.
-bool Search::TimeOver() {
-    if(m_nodesTimeCheck > 1024) {
-        m_nodesTimeCheck = 0;
-        m_elapsedTime = ElapsedTime();
-        if(m_elapsedTime > m_allocatedTime || m_elapsedTime > m_forcedTime)
-            return true;
-    }
-    return false;
-}
-
-// Set search limits from the UCI interface.
-// For normal timed games, estimate the time to spend in the search (allocatedTime).
-// Modes:
-// - infinite: search until manually stopped
-// - depth: search for a fixed depth
-// - moveTime: search for a fixed time
-// - nodes: search for a fixed number of nodes
-void Search::AllocateLimits(Board &board, const Limits& limits) {
-    m_limits = limits;
-    m_nodes = 0;
-
-    // Defaults
-    m_maxDepth = MAX_DEPTH;
-    m_allocatedTime = INFINITE;
-    m_forcedTime = INFINITE;
-    m_forcedNodes = INFINITE_U64;
-
-    // Special search modes
-    if(limits.infinite) { Infinite(); return; }
-    if(limits.depth)    { FixDepth(limits.depth); return; }
-    if(limits.moveTime) { FixTime(limits.moveTime); return; }
-    if(limits.nodes)    { FixNodes(limits.nodes); return; }
-    
-    // Time estimation in normal games
-    const int movesToGo = 20 + 20 * limits.ponderhit;
-
-    COLOR color = board.ActivePlayer();
-
-    int myTime   = (color == WHITE) ? limits.wtime : limits.btime;
-    int yourTime = (color == WHITE) ? limits.btime : limits.wtime;
-    int myInc    = (color == WHITE) ? limits.winc  : limits.binc;
-
-    // Move overhead to account for communication delays
-    const int timeOverhead = 50; //ms
-    const int myTimeSafe = std::max(0, myTime - timeOverhead);
-
-    m_allocatedTime = myTimeSafe / movesToGo + myInc;
-
-    if(m_debugMode)
-        std::cout << "info string TimeAllocation " <<  myTime << " " << yourTime << " " << m_allocatedTime << std::endl;
 }
 
 // Late Move Reductions: reduce the search depth for less-promising moves.

--- a/src/SearchLimits.cpp
+++ b/src/SearchLimits.cpp
@@ -1,0 +1,119 @@
+#include "SearchLimits.h"
+
+namespace {
+    constexpr int TIME_OVERHEAD = 50; //ms
+    constexpr int TIMEOVER_CHECK_NODES = 1024; // Check time every N nodes
+}
+
+void Limits::StartNewSearch(COLOR color, const UCI_Limits& limits) {
+    ResetSignals();
+    AllocateLimits(color, limits);
+    RestartClock();
+}
+
+bool Limits::LimitsReached(u64 nodes) {
+    // Sent by interface
+    if(m_stop)
+        return true;
+    if(m_ponderhit)
+        Apply_PonderHit();
+
+    // Fixed nodes
+    if(nodes >= m_forcedNodes) {
+        Stop();
+        return true;
+    }
+
+    // Time. Calculate every N nodes to avoid expensive time checks.
+    if(nodes >= m_nextTimeCheck) {
+        m_nextTimeCheck = nodes + TIMEOVER_CHECK_NODES;
+        i64 elapsedTime = UpdateElapsedTime();
+        if(elapsedTime >= m_allocatedTime || elapsedTime >= m_forcedTime) {
+            Stop();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+i64 Limits::UpdateElapsedTime() {
+    m_elapsedTime = m_clock.Elapsed();
+    return m_elapsedTime;
+}
+
+uint Limits::CalculateNPS(u64 nodes) const {
+    return static_cast<uint>(1000 * nodes / (m_elapsedTime+1));
+}
+
+void Limits::ResetSignals() {
+    m_stop = false;
+    m_ponderhit = false;
+}
+
+// =============
+// == Private ==
+// =============
+
+// Set search limits from the UCI interface.
+// For normal timed games, estimate the time to spend in the search (allocatedTime).
+// Fixed modes:
+// - infinite: search until manually stopped
+// - depth: search for a fixed depth
+// - moveTime: search for a fixed time
+// - nodes: search for a fixed number of nodes
+void Limits::AllocateLimits(COLOR color, const UCI_Limits& limits) {
+    m_limits = limits;
+    m_color = color;
+
+    // Default to infinite search
+    Infinite();
+
+    // Special search modes
+    if(limits.infinite) { return; }
+    if(limits.ponder)   { return; }
+    if(limits.depth)    { m_forcedDepth = limits.depth; return; }
+    if(limits.moveTime) { m_forcedTime = limits.moveTime; return; }
+    if(limits.nodes)    { m_forcedNodes = limits.nodes; return; }
+
+    // Time estimation in normal games
+    constexpr int ESTIMATED_MOVESTOGO = 20;
+    const int movesToGo = limits.movesToGo ? limits.movesToGo
+                                           : ESTIMATED_MOVESTOGO;
+
+    int myTime   = (color == WHITE) ? limits.wtime : limits.btime;
+    // int yourTime = (color == WHITE) ? limits.btime : limits.wtime;
+    int myInc    = (color == WHITE) ? limits.winc  : limits.binc;
+
+    // Move overhead to account for communication delays
+    const int myTimeSafe = std::max(0, myTime - TIME_OVERHEAD);
+
+    m_allocatedTime = myTimeSafe / movesToGo + myInc;
+}
+
+void Limits::Infinite() {
+    m_forcedDepth = MAX_DEPTH;
+    m_forcedTime = INFINITE_I64;
+    m_forcedNodes = INFINITE_U64;
+    m_allocatedTime = INFINITE_I64;
+}
+
+void Limits::Apply_PonderHit() {
+    assert(m_limits.ponder && m_limits.ponderhit);
+
+    m_ponderhit = false;
+
+    m_limits.ponder = false;
+    m_limits.ponderhit = true;
+
+    AllocateLimits(m_color, m_limits);
+
+    RestartClock(); // without ResetSignals()
+}
+
+void Limits::RestartClock() {
+    m_elapsedTime = 0;
+    m_nextTimeCheck = TIMEOVER_CHECK_NODES;
+
+    m_clock.Start();
+}

--- a/src/Uci.cpp
+++ b/src/Uci.cpp
@@ -4,6 +4,7 @@
 #include "Evaluation.h"
 #include "Hash.h"
 #include "NNUE.h"
+#include "SearchLimits.h"
 #include "Syzygy.h"
 
 #include <iostream>
@@ -54,42 +55,21 @@ void Uci::Launch() {
 
             std::cout << "uciok" << std::endl;
         }
-        else if(token == "debug") {
-            m_search.DebugMode();
-        }
-        else if(token == "isready") {
-            std::cout << "readyok" << std::endl;
-        }
-        else if(token == "setoption") {
-            SetOption(stream);
-        }
+        else if(token == "isready") { std::cout << "readyok" << std::endl; }
+        else if(token == "setoption") { SetOption(stream); }
         else if(token == "ucinewgame") {
+            StopAndJoin();
+
+            m_search.ClearSearch(true);
             m_board.Init();
         }
-        else if(token == "position") {
-            Position(stream);
-        }
-        else if(token == "go") {
-            Go(stream);
-        }
-        else if(token == "stop") {
-            m_search.Stop();
-        }
-        else if(token == "ponderhit") {
-            Limits limits = m_search.GetLimits();
-            limits.infinite = false;
-            limits.ponderhit = true;
-            m_search.AllocateLimits(m_board, limits);
-        }
+        else if(token == "position") { Position(stream); }
+        else if(token == "go") { Go(stream); }
+        else if(token == "stop") { StopAndJoin(); }
+        else if(token == "ponderhit") { m_search.PonderHit(); }
         else if(token == "quit" || token == "q") {
             std::cout << "info string quitting" << std::endl;
-
-            // Wait for the search to finish before exiting
-            m_search.Stop();
-            if(m_searchThread.joinable()) {
-                m_searchThread.join();
-            }
-
+            StopAndJoin();
             break;
         }
         //Non-UCI commands
@@ -147,9 +127,12 @@ void Uci::Launch() {
         }
     }
 
+    StopAndJoin();
 }
 
 void Uci::Bench(int depth, bool verbose) {
+    StopAndJoin();
+
     if(verbose)
         std::cout << "Running benchmark at depth " << depth << "..." << std::endl;
 
@@ -191,18 +174,12 @@ void Uci::Bench(int depth, bool verbose) {
         m_board.SetFen(testPositions[i]);
 
         // Set search limits
-        Limits limits;
-        limits.depth = depth;
-        limits.infinite = false;
-
-        // Run search
-        m_search.AllocateLimits(m_board, limits);
-        m_search.IterativeDeepening(m_board, true);
+        m_search.IterativeDeepening(m_board, UCI_Limits::FixDepth(depth), true);
 
         // Get results using the engine's own calculations
-        int64_t elapsed = m_search.ElapsedTime();
         u64 nodes = m_search.GetNodes();
-        int nps = m_search.GetNps();
+        i64 elapsed = m_search.GetLimits().ElapsedTime();
+        int nps = m_search.GetLimits().CalculateNPS(nodes);
 
         totalNodes += nodes;
         totalTime += elapsed;
@@ -237,13 +214,15 @@ void Uci::Bench(int depth, bool verbose) {
 }
 
 void Uci::Go(std::istringstream &stream) {
+    StopAndJoin();
+    
     std::string token;
-    Limits limits;
+    UCI_Limits limits;
 
     while(stream >> token) {
 
-        if(token == "ponder") { limits.infinite = true; stream >> token; }
-        if(token == "infinite") limits.infinite = true;
+        if(token == "ponder") { limits.ponder = true; }
+        else if(token == "infinite") limits.infinite = true;
         else if(token == "depth") stream >> limits.depth;
         else if(token == "movetime") stream >> limits.moveTime;
         else if(token == "nodes") stream >> limits.nodes;
@@ -254,29 +233,20 @@ void Uci::Go(std::istringstream &stream) {
         else if(token == "movestogo") stream >> limits.movesToGo;
 
         else {
-            std::string temp;
-            stream >> temp;
-            
-            const uint defaultNodes = 200000;
-            P("UNDEFINED GO STATMENT: " << temp << " -- (LOADING DEFAULT VALUES) -- ");
-            P("Nodes: " << defaultNodes);
-            limits.nodes = defaultNodes;
+            const uint DEFAULT_NODES = 150000;
+            P("[WARNING] UNDEFINED GO STATEMENT: " << token << " -> Using default statement: 'go nodes " << DEFAULT_NODES << "'");
+            limits.nodes = DEFAULT_NODES;
             break;
         }
 
     }
 
-    // Wait thread of the previous search
-    if(m_searchThread.joinable()) {
-        m_searchThread.join();
-    }
-
-    m_search.AllocateLimits(m_board, limits);
-
-    m_searchThread = std::thread(&Uci::StartSearch, this);
+    m_searchThread = std::thread(&Uci::StartSearch, this, limits);
 }
 
 void Uci::Position(std::istringstream &stream) {
+    StopAndJoin();
+
     std::string token;
 
     while(stream >> token) {
@@ -305,6 +275,8 @@ void Uci::Position(std::istringstream &stream) {
 }
 
 void Uci::SetOption(std::istringstream &stream) {
+    StopAndJoin();
+
     std::string token;
     stream >> token; //should be 'name'
     if(token != "name")
@@ -388,6 +360,73 @@ void Uci::SetOption(std::istringstream &stream) {
     }
 }
 
-void Uci::StartSearch() {
-    m_search.IterativeDeepening(m_board);
+void Uci::StartSearch(UCI_Limits limits) {
+    m_search.IterativeDeepening(m_board, limits);
+}
+
+void Uci::StopAndJoin() {
+    m_search.Stop();
+
+    // Thread join
+    if(m_searchThread.joinable()) {
+        m_searchThread.join();
+    }
+}
+
+// =================
+// == UCI Outputs ==
+// =================
+
+void Uci::Output(int depth, int seldepth, int score, u64 nodes, i64 time, uint nps, int tbHits, BOUND_TYPE bound, const std::string& PV) {
+    if(!UCI_OUTPUT) return;
+
+    std::cout << "info depth " << depth;
+    std::cout << " seldepth " << seldepth;
+
+    if(IsMateValue(score)) {
+        int mateScore = (score > 0) ?  MATESCORE_MAX - score + 1
+                                    : -MATESCORE_MAX - score - 1;
+        std::cout << " score mate " << mateScore / 2; //return mate in moves, not in plies
+    } else {
+        std::cout << " score cp " << score;
+    }
+    if(bound == BOUND_TYPE::LOWER_BOUND) std::cout << " lowerbound";
+    if(bound == BOUND_TYPE::UPPER_BOUND) std::cout << " upperbound";
+
+    std::cout << " time " << time;
+    std::cout << " nodes " << nodes;
+    std::cout << " nps " << nps;
+
+    if(time > 1000)
+        std::cout << " hashfull " << Hash::tt.Occupancy();
+    if(tbHits)
+        std::cout << " tbhits " << tbHits;
+
+    std::cout << " pv " << PV;
+    std::cout << std::endl;
+}
+
+void Uci::RootUpdate(int depth, int seldepth, int currMoveNumber, const std::string& currMove, u64 nodes, i64 time, uint nps, int tbHits) {
+    if(!UCI_OUTPUT) return;
+    if(time < UCI_OUTPUT_ROOTMAX_MINTIME) return;
+    
+    std::cout << "info depth " << depth
+              << " seldepth " << seldepth
+              << " currmovenumber " << currMoveNumber
+              << " currmove " << currMove
+              << " time " << time
+              << " nodes " << nodes
+              << " nps " << nps;
+    if(tbHits)
+        std::cout << " tbhits " << tbHits;
+    std::cout << std::endl;
+}
+
+void Uci::BestMove(const std::string& bestmove, const std::string& pondermove) {
+    if(!UCI_OUTPUT) return;
+
+    std::cout << "bestmove " << bestmove;
+    if(UCI_PONDER && !pondermove.empty())
+        std::cout << " ponder " << pondermove;
+    std::cout << std::endl;
 }

--- a/src/Uci.cpp
+++ b/src/Uci.cpp
@@ -27,6 +27,10 @@ Uci::Uci() :
     m_search(Search())
 {}
 
+Uci::~Uci() {
+    StopAndJoin();
+}
+
 void Uci::Launch() {
 
     std::string line;
@@ -126,8 +130,6 @@ void Uci::Launch() {
             std::cout << "Command not valid: " << line << std::endl;
         }
     }
-
-    StopAndJoin();
 }
 
 void Uci::Bench(int depth, bool verbose) {
@@ -241,7 +243,8 @@ void Uci::Go(std::istringstream &stream) {
 
     }
 
-    m_searchThread = std::thread(&Uci::StartSearch, this, limits);
+    m_limits = limits; // To avoid copies in std::thread that may cause memory misalignments
+    m_searchThread = std::thread(&Uci::StartSearch, this);
 }
 
 void Uci::Position(std::istringstream &stream) {
@@ -360,8 +363,8 @@ void Uci::SetOption(std::istringstream &stream) {
     }
 }
 
-void Uci::StartSearch(UCI_Limits limits) {
-    m_search.IterativeDeepening(m_board, limits);
+void Uci::StartSearch() {
+    m_search.IterativeDeepening(m_board, m_limits);
 }
 
 void Uci::StopAndJoin() {

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -24,10 +24,10 @@ namespace Utils {
     void Clock::Start() {
         m_start = HighResClock::now();
     }
-    int64_t Clock::Elapsed() {
+    int64_t Clock::Elapsed() const {
         return std::chrono::duration_cast<std::chrono::milliseconds>(HighResClock::now() - m_start).count();
     }
-    int64_t Clock::ElapsedNanoseconds() {
+    int64_t Clock::ElapsedNanoseconds() const {
         return std::chrono::duration_cast<std::chrono::nanoseconds>(HighResClock::now() - m_start).count();
     }
 

--- a/src/gensfen/GenSFen.cpp
+++ b/src/gensfen/GenSFen.cpp
@@ -134,7 +134,6 @@ void GenSFen::Random(std::string filename) {
 
     Board board;
     Search search;
-    search.FixDepth(7);
     State state;
 
     const int maxGames = INFINITE;
@@ -184,7 +183,7 @@ void GenSFen::RandomBenchmark(int maxGames) {
 
     Board board;
     Search search;
-    search.FixDepth(7);
+    UCI_Limits limits = UCI_Limits::FixDepth(7);
 
     for(int n_game = 1; n_game <= maxGames; n_game++) {
         clock.Start();
@@ -194,11 +193,11 @@ void GenSFen::RandomBenchmark(int maxGames) {
 
         clock.Start();
 
-        search.IterativeDeepening(board);
+        search.IterativeDeepening(board, limits);
         int score_active = search.BestScore();
 
         board.MakeNull();
-        search.IterativeDeepening(board);
+        search.IterativeDeepening(board, limits);
         int score_inactive = search.BestScore();
         board.TakeNull();
 
@@ -221,7 +220,6 @@ void GenSFen::RandomBenchmark(int maxGames) {
 
 int GenSFen::GenerateRandomPosition(Board& board, std::string& position) {
     Search search_depth1;
-    search_depth1.FixDepth(1);
 
     bool validScore = false;
     int tries = 0;
@@ -233,13 +231,13 @@ int GenSFen::GenerateRandomPosition(Board& board, std::string& position) {
         int nPieces = PopCount(board.AllPieces());
         if(NoMoves(board) || nPieces <= 6)
             continue;
-        search_depth1.IterativeDeepening(board);
+        search_depth1.IterativeDeepening(board, UCI_Limits::FixDepth(1));
         int score_active = search_depth1.BestScore();
 
         board.MakeNull();
         if(NoMoves(board))
             continue;
-        search_depth1.IterativeDeepening(board);
+        search_depth1.IterativeDeepening(board, UCI_Limits::FixDepth(1));
         int score_inactive = search_depth1.BestScore();
 
         bool evalPass = (abs(score_active) < 66) || (abs(score_inactive) < 66);
@@ -257,16 +255,14 @@ int GenSFen::GenerateRandomPosition(Board& board, std::string& position) {
 // - Best move is quiet at low depths (to skip trivial captures)
 // - Evaluation conditions: At least one color has [-200,200]. Both colors have [-800,800].
 void GenSFen::WriteEvals(Board& board, Search& search, std::ofstream& outputFile, CurrentPosition& currentPosition, int thresholdEval, int thresholdEvalBoth, uint minPly) {
-    search.FixDepth(5);
-    search.IterativeDeepening(board);
+    search.IterativeDeepening(board, UCI_Limits::FixDepth(5));
     currentPosition.calculatedDepth = 5;
     currentPosition.bestMove = search.BestMove();
     
     if(board.Ply() < minPly || board.IsCheck() || !search.BestMove().IsQuiet())
         return;
 
-    search.FixDepth(7);
-    search.IterativeDeepening(board);
+    search.IterativeDeepening(board, UCI_Limits::FixDepth(7));
     currentPosition.calculatedDepth = 7;
     currentPosition.bestMove = search.BestMove();
 
@@ -284,16 +280,14 @@ void GenSFen::WriteEvals(Board& board, Search& search, std::ofstream& outputFile
     }
 
     // Low depth. Check that move is quiet.
-    search.FixDepth(5);
-    search.IterativeDeepening(board);
+    search.IterativeDeepening(board, UCI_Limits::FixDepth(5));
     if(!search.BestMove().IsQuiet()) {
         board.TakeNull();
         return;
     }
 
     // Normal depth
-    search.FixDepth(7);
-    search.IterativeDeepening(board);
+    search.IterativeDeepening(board, UCI_Limits::FixDepth(7));
     eval[1-color] = search.BestScore();
 
     // Eval conditions

--- a/tests/suite-WAC.cpp
+++ b/tests/suite-WAC.cpp
@@ -25,8 +25,8 @@ protected:
 
 TEST_F(MySuite, Fine70) {
     board.SetFen("8/k7/3p4/p2P1p2/P2P1P2/8/8/K7 w - -");
-    search.FixTime(3000);
-    search.IterativeDeepening(board, true);
+    UCI_Limits limits = UCI_Limits::FixTime(3000);
+    search.IterativeDeepening(board, limits, true);
     EXPECT_EQ(search.BestMove().Notation(), "a1b1");
 }
 
@@ -45,8 +45,8 @@ TEST(WAC, WAC) {
 
         board.SetFen(pos.fen);
 
-        search.FixTime(3000);
-        search.IterativeDeepening(board, true);
+        UCI_Limits limits = UCI_Limits::FixTime(3000);
+        search.IterativeDeepening(board, limits, true);
         Move move = search.BestMove();
 
         std::string toSq = move.Notation().substr(2,2);

--- a/tests/test-Misc.cpp
+++ b/tests/test-Misc.cpp
@@ -10,6 +10,7 @@ protected:
     Board board;
     Search search;
     CoutHelper verbosity;
+    UCI_Limits limits = UCI_Limits::FixDepth(1);
     void SetUp() override {
         verbosity.Mute();
     }
@@ -21,8 +22,7 @@ protected:
 //https://www.talkchess.com/forum/viewtopic.php?p=710549
 TEST_F(PositionMisc, QuiescenceExplosion) {
     board.SetFen("1QqQqQq1/r6Q/Q6q/q6Q/B2q4/q6Q/k6K/1qQ1QqRb w - -");
-    search.FixDepth(1);
-    search.IterativeDeepening(board, true);
+    search.IterativeDeepening(board, limits, true);
     EXPECT_EQ(search.BestScore(), MATESCORE_MAX - 1);
 }
 
@@ -31,8 +31,7 @@ TEST_F(PositionMisc, QuiescenceExplosion) {
 // Difficult mate in #5. Too much pruning will see mate in #6
 // TEST_F(PositionMisc, Mate1) {
 //     board.SetFen("8/3N4/6p1/1p5p/5b1p/P2k2n1/1B6/3KQ3 w - -");
-//     search.FixTime(2000);
-//     search.IterativeDeepening(board, true);
+//     search.IterativeDeepening(board, true, UCI_Limits::FixTime(2000));
 //     EXPECT_EQ(search.BestMove().Notation(), "b2a1");
 // }
 

--- a/tests/test-Search.cpp
+++ b/tests/test-Search.cpp
@@ -19,132 +19,133 @@ protected:
     Search search;
     Board board;
     int depth = 9; //short: 5, long: 7
+    UCI_Limits limits;
     int time = 1000 + (depth > 5)*10000;
     void SetUp() override {
         std::cout.rdbuf(nullptr);
-        search.FixDepth(depth);
+        limits = UCI_Limits::FixDepth(depth);
     }
 };
 
 TEST_F(ShortSearch, Start) {
-    search.FixDepth(depth+1);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth+1);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 // RG = Position from Real Game
 TEST_F(ShortSearch, RG1) {
     board.SetFen("r2qkb2/1b1p1pp1/p1n1p3/1pp4r/4PB2/1BNP2QP/PPP2P1P/R3R1K1 w q - 3 16");
-    search.FixDepth(depth-1);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth-1);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 // Nd5
 TEST_F(ShortSearch, RG2_Nd5) {
     board.SetFen("r2qkb2/1b1p1pp1/p1n1p3/2p4r/Pp2PB2/1BNP2QP/1PP2P1P/R3R1K1 w q - 0 17");
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 //Failed with Rad8 (order better the root moves)
 TEST_F(ShortSearch, RG3) {
     board.SetFen("r4rk1/pppbqppp/2n1pn2/1B1p4/3P4/P1B1P3/1PPN1PPP/R2Q1RK1 b - - 0 10");
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 //Failed with Rc1, losing a bishop
 TEST_F(ShortSearch, RG4) {
     board.SetFen("8/5p2/2B2k2/p7/1pr5/4r3/P1P3P1/3R2K1 w - - 12 48");
-    search.FixDepth(depth+1);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth+1);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 //Test passed pawn, Rd4+, most engines realize at depth 6/7
 TEST_F(ShortSearch, RG5_Rd4) {
     board.SetFen("3r2k1/7p/p7/3r1R2/PQ2K1P1/3p2PP/1P2b3/8 b - - 1 35");
-    search.FixDepth(depth+3);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth+3);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 //Crowdy early-final position
 TEST_F(ShortSearch, RG6_crowdy) {
     board.SetFen("8/8/1p1rknp1/pBb5/2P1nP1p/P1N4P/1BP3K1/4R3 b - - 14 41");
-    search.FixDepth(depth+3);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth+3);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 // Failed with Rc8, depth 8, 8s
 TEST_F(ShortSearch, RG7) {
     board.SetFen("4r1k1/1p3ppp/b7/3R4/1pn5/4P3/3N1PPP/R5K1 b - - 0 30");
-    search.FixDepth(depth+3);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth+3);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 // bm Qf3, failed to spot at depth 11, 2min
 TEST_F(ShortSearch, RG8_Qf3) {
     board.SetFen("2kr2nr/n6p/p3R3/1p3P2/P2q4/2p5/2PN2P1/1RBQ3K w - - 0 26");
-    search.FixDepth(depth);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 // bm b5, not seen until depth 9 (might be related to mate detection)
 TEST_F(ShortSearch, RG9_b5) {
     board.SetFen("8/p1r2kp1/1p2bq2/2r2p2/QP2p3/P5PP/2PR1PB1/1K1R4 b - - 0 35");
-    search.FixDepth(depth+2);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth+2);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 // Failed with fxg5, depth 10, 4s
 TEST_F(ShortSearch, RG10_F_fxg5) {
     board.SetFen("6r1/1ppnr1kp/pq1b1p2/2p1pPP1/P3P3/1P1P1N2/R1PB3Q/5R1K b - - 2 30");
-    search.FixDepth(depth);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 // Failed with g3 (light squares weakness)
 TEST_F(ShortSearch, RG11_F_g3) {
     board.SetFen("r3r1k1/1p3ppp/2nQ4/4Nb2/p4P1q/2P5/PPP3PP/R1BR2K1 w - - 5 18");
-    search.FixDepth(depth);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 // Mis-evaluated endgame with -0.14 d18/3s
 TEST_F(ShortSearch, RG12_endgame) {
     board.SetFen("5b2/p1p2p2/7p/4kP2/PpPp2P1/5P2/4K3/4R3 b - - 6 36");
-    search.FixDepth(depth+3);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth+3);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 // Be careful with king safety! Failed with Bd2 0.13s
 TEST_F(ShortSearch, RG13_kingSafetyI) {
     board.SetFen("5r1bk2r1/ppp2p2/3p1b1p/1Q1P4/2P1P2q/2N2R2/PP2B1nP/R1B4K w - - 2 15");
-    search.FixDepth(depth);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 // Be careful with king safety! Failed with Nxc5 +0.49 d12/5s
 TEST_F(ShortSearch, RG14_kingSafetyII) {
     board.SetFen("r2qk2r/pp3ppp/n1p5/2b2b2/Q1P1N1n1/5N2/PP1PBPPP/R1B1K2R w KQkq - 8 10");
-    search.FixDepth(depth+1);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth+1);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 // Weird king move. Kf1 +0.19 d14/5s
 TEST_F(ShortSearch, RG15_weirdMove) {
     board.SetFen("rnb1kbnr/ppp1pppp/6q1/8/8/5N2/PPPPBPPP/RNBQK2R w KQkq - 4 5");
-    search.FixDepth(depth+1);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth+1);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 // Other engine eval raise. c5 +0.12 d13/3s
 TEST_F(ShortSearch, RG16) {
     board.SetFen("r1bqr1k1/ppp2ppp/3p1n2/4n3/2PNP3/2P2P2/P3B1PP/1RBQ1RK1 b - - 1 11");
-    search.FixDepth(depth);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }
 // Failed with e5 +1.99 d10/2s
 TEST_F(ShortSearch, RG17) {
     board.SetFen("2b3r1/6rk/2NR3p/1pN2p2/4Pp1P/1PP2Pn1/P5PK/4R3 w - - 0 41");
-    search.FixDepth(depth+1);
-    search.IterativeDeepening(board, true);
-    EXPECT_LE(search.ElapsedTime(), time);
+    limits = UCI_Limits::FixDepth(depth+1);
+    search.IterativeDeepening(board, limits, true);
+    EXPECT_LE(search.GetLimits().ElapsedTime(), time);
 }


### PR DESCRIPTION
**Refactor: new file SearchLimits.cpp**

- **SearchLimits**: move there all time-management logic, forced termination (nodes, time, depth), and UCI signals stop/ponderhit. All that logic was previously on `Search.cpp`.
- **UCI**: move to `UCI.cpp` all UCI outputs (`std::cout`). Previously on `Search.cpp`.
- **UCI**: safer multi-thread (`stop` search and `join()` thread before any major input).
- **Fix**: safety net in NegaMax if `MAX_PLY` is reached, to prevent crashes.

```
bench 2959622

Elo   | -0.86 +- 7.62 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.16 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 4038 W: 1285 L: 1295 D: 1458
Penta | [147, 454, 808, 482, 128]
```