### PR TITLE
bugfix: NNUE misalignment (in Windows)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,11 @@ jobs:
           - os: windows-2025
             build_type: Release
             compiler: g++
-          # DEBUG
+          # DEBUG - Windows
+          - os: windows-2025
+            build_type: Debug
+            compiler: g++
+          # DEBUG - Linux
           - os: ubuntu-latest
             build_type: Debug
             compiler: g++

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build*
+dev/
 docs/
 testing/
 versions/

--- a/src/NNUE.cpp
+++ b/src/NNUE.cpp
@@ -239,9 +239,8 @@ void NNUE::ActivateReLU(const i16* input, i16* output, int size) const {
 
 namespace {
     #if defined(__AVX2__)
-    //Horizontal sum of 8 integers (256-bits)
-    inline i32 HorizontalSum256(__m256i v) {
-        __m128i x = _mm_add_epi32(_mm256_castsi256_si128(v), _mm256_extracti128_si256(v, 1));
+    // Horizontal sum of 4 integers (128-bits)
+    inline i32 HorizontalSum128(__m128i x) {
         x = _mm_add_epi32(x, _mm_srli_si128(x, 8));
         x = _mm_add_epi32(x, _mm_srli_si128(x, 4));
         return _mm_cvtsi128_si32(x);
@@ -269,7 +268,9 @@ void NNUE::ComputeLayer(const i16* inputLayer, T* outputLayer,
                 dot = _mm256_add_epi32(dot, product);
             }
 
-            sum += HorizontalSum256(dot);
+            __m128i x = _mm_add_epi32(_mm256_castsi256_si128(dot), _mm256_extracti128_si256(dot, 1));
+
+            sum += HorizontalSum128(x);
         #else
             for(int i = 0; i < dimInput; i++) {
                 sum += inputLayer[i] * weights[offset + i];

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -45,7 +45,6 @@ using namespace Sorting;
 #include <algorithm> //max(), clamp()
 #include <cmath> //INFINITY
 #include <iomanip> //debug output
-#include <format>
 
 // Search parameters
 const int MAX_QS_PLIES = 128;  // Maximum depth limit for quiescence search
@@ -723,7 +722,7 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
     assert(m_ply < MAX_PLY);
 
     D( m_debug.Increment("Quiescence: _: Hits"); );
-    D( if(m_plyqs <= 2 || m_plyqs % 5 == 0) m_debug.Increment("Quiescence: QPly " + std::format("{:03}", m_plyqs)) );
+    D( if(m_plyqs <= 2 || m_plyqs % 5 == 0) m_debug.Increment("Quiescence: QPly " + std::to_string(m_plyqs)) );
 
     m_nodes++;
     m_nodesTimeCheck++;


### PR DESCRIPTION
**Fix: segfault in Windows** machines under certain circumstances.

- Fix: in Windows the 32-bit alignment in stack variables is not ensured. Passing __m256i by value in `HorizontalSum256` triggered an intermitent segfault error when not inlined by the compiler.
Now converted to a safer `HorizontalSum128`.
- Fix: in Debug mode, complex positions would generate a stack overflow. Solved by removing the memory-consuming `std::format` calls.
- CI: add a new Debug build for windows-2025, which triggered the above problems.

```
bench 2959622

Elo   | 1.87 +- 9.97 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.04 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 2420 W: 791 L: 778 D: 851
Penta | [93, 249, 511, 266, 91]
```