### PR TITLE
enhance: time management

### DIFF
--- a/include/SearchLimits.h
+++ b/include/SearchLimits.h
@@ -35,7 +35,7 @@ class Limits {
 public:
     Limits() = default;
 
-    void StartNewSearch(COLOR color, const UCI_Limits& limits);
+    void StartNewSearch(COLOR color, const UCI_Limits& limits, size_t movesSize);
 
     bool LimitsReached(u64 nodes);
 
@@ -58,7 +58,7 @@ private:
     // =============
     // == Methods ==
     // =============
-    void AllocateLimits(COLOR color, const UCI_Limits& limits);
+    void AllocateLimits(COLOR color, const UCI_Limits& limits, size_t movesSize);
 
     void Infinite();
     
@@ -83,6 +83,10 @@ private:
     i64 m_forcedTime = 0; // Fixed time limit (ms)
     u64 m_forcedNodes = 0; // Fixed nodes limit
 
+    // Root-level information
+    size_t m_movesSize = 0; // Number of legal moves in the root position (used for time estimation)
+
+    // UCI signals
     std::atomic<bool> m_stop = false; // Flag to stop the search (time limit, user input, etc.)
     std::atomic<bool> m_ponderhit = false; // Flag to indicate that the ponder move was played
 };

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -115,7 +115,10 @@ void Search::ClearSearch(bool fullClear) {
 void Search::IterativeDeepening(Board &board, const UCI_Limits& limits, bool fullClear) {
     ClearSearch(fullClear);
 
-    m_limits.StartNewSearch(board.ActivePlayer(), limits);
+    MoveList rootMoves = MoveGenerator::GenerateMoves(board);
+    size_t movesSize = rootMoves.size();
+
+    m_limits.StartNewSearch(board.ActivePlayer(), limits, movesSize);
     
     D( m_debug.Increment("IterativeDeepening: _: Start") );
     m_searchCount++;

--- a/src/SearchLimits.cpp
+++ b/src/SearchLimits.cpp
@@ -116,6 +116,7 @@ void Limits::Apply_PonderHit() {
     m_limits.ponderhit = true;
 
     AllocateLimits(m_color, m_limits, m_movesSize);
+    m_allocatedTime /= 2;
 
     RestartClock(); // without ResetSignals()
 }

--- a/src/SearchLimits.cpp
+++ b/src/SearchLimits.cpp
@@ -5,9 +5,11 @@ namespace {
     constexpr int TIMEOVER_CHECK_NODES = 1024; // Check time every N nodes
 }
 
-void Limits::StartNewSearch(COLOR color, const UCI_Limits& limits) {
+void Limits::StartNewSearch(COLOR color, const UCI_Limits& limits, size_t movesSize) {
+    m_movesSize = movesSize;
+
     ResetSignals();
-    AllocateLimits(color, limits);
+    AllocateLimits(color, limits, m_movesSize);
     RestartClock();
 }
 
@@ -62,7 +64,7 @@ void Limits::ResetSignals() {
 // - depth: search for a fixed depth
 // - moveTime: search for a fixed time
 // - nodes: search for a fixed number of nodes
-void Limits::AllocateLimits(COLOR color, const UCI_Limits& limits) {
+void Limits::AllocateLimits(COLOR color, const UCI_Limits& limits, size_t movesSize) {
     m_limits = limits;
     m_color = color;
 
@@ -92,6 +94,10 @@ void Limits::AllocateLimits(COLOR color, const UCI_Limits& limits) {
 
     // Safety net: don't use more than the remaining time
     m_allocatedTime = std::min(m_allocatedTime, (i64)myTimeSafe);
+
+    // Extra adjustments: root-level information
+    if(movesSize == 1)
+        m_allocatedTime /= 3;
 }
 
 void Limits::Infinite() {
@@ -109,7 +115,7 @@ void Limits::Apply_PonderHit() {
     m_limits.ponder = false;
     m_limits.ponderhit = true;
 
-    AllocateLimits(m_color, m_limits);
+    AllocateLimits(m_color, m_limits, m_movesSize);
 
     RestartClock(); // without ResetSignals()
 }

--- a/src/SearchLimits.cpp
+++ b/src/SearchLimits.cpp
@@ -75,12 +75,8 @@ void Limits::AllocateLimits(COLOR color, const UCI_Limits& limits) {
     if(limits.depth)    { m_forcedDepth = limits.depth; return; }
     if(limits.moveTime) { m_forcedTime = limits.moveTime; return; }
     if(limits.nodes)    { m_forcedNodes = limits.nodes; return; }
-
+    
     // Time estimation in normal games
-    constexpr int ESTIMATED_MOVESTOGO = 20;
-    const int movesToGo = limits.movesToGo ? limits.movesToGo
-                                           : ESTIMATED_MOVESTOGO;
-
     int myTime   = (color == WHITE) ? limits.wtime : limits.btime;
     // int yourTime = (color == WHITE) ? limits.btime : limits.wtime;
     int myInc    = (color == WHITE) ? limits.winc  : limits.binc;
@@ -88,7 +84,14 @@ void Limits::AllocateLimits(COLOR color, const UCI_Limits& limits) {
     // Move overhead to account for communication delays
     const int myTimeSafe = std::max(0, myTime - TIME_OVERHEAD);
 
-    m_allocatedTime = myTimeSafe / movesToGo + myInc;
+    constexpr int ESTIMATED_MOVESTOGO = 20;
+    const int movesToGo = limits.movesToGo ? limits.movesToGo
+                                           : ESTIMATED_MOVESTOGO;
+
+    m_allocatedTime = (myTimeSafe / movesToGo) + myInc;
+
+    // Safety net: don't use more than the remaining time
+    m_allocatedTime = std::min(m_allocatedTime, (i64)myTimeSafe);
 }
 
 void Limits::Infinite() {


### PR DESCRIPTION
**Enhance: time management**

- Use 1/3 the allocated time if only 1 legal move in current position
- Use 1/2 the allocated time after ponderhit
- Fix: prevent time loses when the increment is greater than the remaining time in the clock

```
bench 2959622

Elo   | 3.73 +- 10.77 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1862 W: 630 L: 610 D: 622
Penta | [47, 216, 403, 200, 65]
```