### PR TITLE
performance: relax TT probe

### DIFF
--- a/include/Hash.h
+++ b/include/Hash.h
@@ -37,7 +37,7 @@ public:
     ~TT();
 
     void Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth, int ply, int age, int eval = NO_EVAL);
-    TTEntry* Probe(u64 zkey, int depth);
+    TTEntry* Probe(u64 zkey);
 
     void Clear();
     void SetSize(int sizeInMB);

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -122,7 +122,7 @@ void Board::ShowHashMoves() {
 
     for(auto move : moves)  {
         MakeMove(move);
-        TTEntry* ttEntry = Hash::tt.Probe(ZKey(), 0);
+        TTEntry* ttEntry = Hash::tt.Probe(ZKey());
         if(ttEntry) {
             P(move.Notation() << " " << static_cast<u8>(ttEntry->type) << "\t" << ttEntry->score);
         }

--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -51,17 +51,15 @@ void TT::Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth,
     }
 }
 
-TTEntry* TT::Probe(u64 zkey, int depth) {
+TTEntry* TT::Probe(u64 zkey) {
     u64 index = zkey & m_mask;
     TTEntry* entry = &m_entries[index];
 
-    const bool zkeyEqual = UpperBits<u32>(zkey) == entry->zkey;
-    const bool higherDepth = entry->depth >= depth;
-    if(zkeyEqual && higherDepth) {
+    const bool zkeyMatch = (UpperBits<u32>(zkey) == entry->zkey);
+    if(zkeyMatch)
         return entry;
-    } else {
-        return nullptr;
-    }
+
+    return nullptr;
 }
 
 void TT::Clear() {

--- a/src/Heuristics.cpp
+++ b/src/Heuristics.cpp
@@ -13,7 +13,7 @@ namespace {
 
     void RateMoves(Board &board, MoveList &moves, TT& tt, const Heuristics &heuristics, int ply) {
         Move hashMove;
-        TTEntry* ttEntry = tt.Probe(board.ZKey(), 0); //shallowest
+        TTEntry* ttEntry = tt.Probe(board.ZKey());
         if(ttEntry)
             hashMove = ttEntry->bestMove;
 

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -359,19 +359,22 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
     int alphaOriginal = alpha; // For TT entry type calculation
     int ttEval = NO_EVAL;
     
-    TTEntry* ttEntry = Hash::tt.Probe(board.ZKey(), depth);
-    if(ttEntry && !isPV) {
-        D( m_debug.Increment("NegaMax: TT Hit") );
-
-        int score = Hash::tt.ScoreFromHash(ttEntry->score, m_ply);
+    TTEntry* ttEntry = Hash::tt.Probe(board.ZKey());
+    if(ttEntry) {
+        D( m_debug.Increment("NegaMax: TT: Hit") );
         ttEval = ttEntry->eval;
 
-        if( ttEntry->type == TTENTRY_TYPE::EXACT
-            || (ttEntry->type == TTENTRY_TYPE::UPPER_BOUND && score <= alpha)
-            || (ttEntry->type == TTENTRY_TYPE::LOWER_BOUND && score >= beta)
-        ) {
-            D( m_debug.Increment("NegaMax: TT Hit: Cut-Off") );
-            return score;
+        if(!isPV && ttEntry->depth >= depth) {
+            D( m_debug.Increment("NegaMax: TT: Higher Depth") );
+            int score = Hash::tt.ScoreFromHash(ttEntry->score, m_ply);
+
+            if( ttEntry->type == TTENTRY_TYPE::EXACT
+                || (ttEntry->type == TTENTRY_TYPE::UPPER_BOUND && score <= alpha)
+                || (ttEntry->type == TTENTRY_TYPE::LOWER_BOUND && score >= beta)
+            ) {
+                D( m_debug.Increment("NegaMax: TT: Cut-Off") );
+                return score;
+            }
         }
     }
 
@@ -663,19 +666,20 @@ int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
 
     // Probe transposition table.
     // Only non-PV nodes: PV nodes require the most accurate score possible.
-    TTEntry* ttEntry = Hash::tt.Probe(board.ZKey(), 0);
+    TTEntry* ttEntry = Hash::tt.Probe(board.ZKey());
     if(ttEntry) {
-        D( m_debug.Increment("Quiescence: TT Hit: Exists") );
+        D( m_debug.Increment("Quiescence: TT: Hit") );
         hashMove = ttEntry->bestMove;
         ttEval = ttEntry->eval;
 
         if(!isPV) {
+            D( m_debug.Increment("Quiescence: TT: !isPV") );
             int score = Hash::tt.ScoreFromHash(ttEntry->score, m_ply);
             if( ttEntry->type == TTENTRY_TYPE::EXACT
                 || (ttEntry->type == TTENTRY_TYPE::UPPER_BOUND && score <= alpha)
                 || (ttEntry->type == TTENTRY_TYPE::LOWER_BOUND && score >= beta)
             ) {
-                D( m_debug.Increment("Quiescence: TT Hit: Return score") );
+                D( m_debug.Increment("Quiescence: TT: Cut-Off") );
                 return score;
             }
         }

--- a/tests/test-Hash.cpp
+++ b/tests/test-Hash.cpp
@@ -12,7 +12,7 @@ TEST(TT, MateScoreAdjustment) {
     // Mate scores get adjusted by ply
     int mateIn5 = MATESCORE_MAX - 5;
     tt.Store(zkey, mateIn5, TTENTRY_TYPE::EXACT, Move(), 10, /*ply=*/3, 0);
-    TTEntry* entry = tt.Probe(zkey, 10);
+    TTEntry* entry = tt.Probe(zkey);
     EXPECT_EQ(tt.ScoreFromHash(entry->score, 3), mateIn5);
     EXPECT_EQ(tt.ScoreFromHash(entry->score, 0), MATESCORE_MAX - 2);
 }
@@ -25,7 +25,7 @@ TEST(TT, NormalScoreUnchanged) {
     // Normal scores should NOT be adjusted
     int normalScore = 150;
     tt.Store(zkey, normalScore, TTENTRY_TYPE::EXACT, Move(), 10, /*ply=*/5, 0);
-    TTEntry* entry = tt.Probe(zkey, 10);
+    TTEntry* entry = tt.Probe(zkey);
     EXPECT_EQ(tt.ScoreFromHash(entry->score, 0), normalScore);
     EXPECT_EQ(tt.ScoreFromHash(entry->score, 10), normalScore);
 }


### PR DESCRIPTION
**Performance: use the ttEval information if present in TT**, regardless of depth

The depth condition is taken out of `TT::Probe`. That way we can make use of the **ttEval** information, even when a TT cut-off is not possible. That check is now performed by the Search, not `TT::Probe`.
We were ignoring the ttEval stored in the Hash if the depth was lower, so this is a pure performance patch.

```
bench 2959622

Elo   | 6.37 +- 12.36 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.05 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1472 W: 504 L: 477 D: 491
Penta | [47, 148, 325, 163, 53]
```