### PR TITLE
performance: re-use hash move for sorting

### DIFF
--- a/include/Heuristics.h
+++ b/include/Heuristics.h
@@ -14,7 +14,7 @@ const int MAX_BONUS = 400;
 constexpr int MAX_HISTORY_VALUE = std::bit_floor( (uint)INFINITE / MAX_BONUS );
 
 namespace Sorting {
-    void SortMoves(Board &board, MoveList &moves, TT& tt, const Heuristics &heuristics, int ply);
+    void SortMoves(Board &board, MoveList &moves, Move hashMove, const Heuristics &heuristics, int ply);
     void SortEvasions(Board &board, MoveList &moves, Move hashMove);
     void SortTactical(Board &board, MoveList &moves, Move hashMove);
 }

--- a/src/Heuristics.cpp
+++ b/src/Heuristics.cpp
@@ -11,12 +11,8 @@
 //Unnamed namespace (private functions)
 namespace {
 
-    void RateMoves(Board &board, MoveList &moves, TT& tt, const Heuristics &heuristics, int ply) {
-        Move hashMove;
-        TTEntry* ttEntry = tt.Probe(board.ZKey());
-        if(ttEntry)
-            hashMove = ttEntry->bestMove;
-
+    void RateMoves(Board &board, MoveList &moves, Move hashMove, const Heuristics &heuristics, int ply) {
+    
         Move killer1 = heuristics.killer.Primary(ply);
         Move killer2 = heuristics.killer.Secondary(ply);
         Move killer3, killer4;
@@ -125,8 +121,8 @@ namespace {
 
 } //unnamed namespace
 
-void Sorting::SortMoves(Board &board, MoveList& moves, TT& tt, const Heuristics &heuristics, int ply) {
-    RateMoves(board, moves, tt, heuristics, ply);
+void Sorting::SortMoves(Board &board, MoveList& moves, Move hashMove, const Heuristics &heuristics, int ply) {
+    RateMoves(board, moves, hashMove, heuristics, ply);
     std::ranges::sort(moves, ByScore);
 }
 

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -211,10 +211,15 @@ int Search::RootMax(Board &board, int depth, int alpha, int beta) {
     MoveList moves = MoveGenerator::GenerateMoves(board);
     D( if(depth == 1) P("Number of moves in root position: " << moves.size()) );
 
-    SortMoves(board, moves, Hash::tt, m_heuristics, m_ply);
+    Move hashMove; // For move ordering
+    TTEntry* ttEntry = Hash::tt.Probe(board.ZKey());
+    if(ttEntry)
+        hashMove = ttEntry->bestMove;
+
+    SortMoves(board, moves, hashMove, m_heuristics, m_ply);
 
     if(!m_bestMove.MoveType() && !moves.empty())
-        m_bestMove = moves[0]; // Life jacket if first move at depth 1 is not completed
+        m_bestMove = moves[0]; // Safety net if first move at depth 1 is not completed
 
     int moveNumber = 0;
 
@@ -357,12 +362,15 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
     Move bestMove; // For later storage in the TT
     int bestScore = NO_SCORE;
     int alphaOriginal = alpha; // For TT entry type calculation
+
+    Move hashMove; // For move ordering
     int ttEval = NO_EVAL;
     
     TTEntry* ttEntry = Hash::tt.Probe(board.ZKey());
     if(ttEntry) {
         D( m_debug.Increment("NegaMax: TT: Hit") );
         ttEval = ttEntry->eval;
+        hashMove = ttEntry->bestMove;
 
         if(!isPV && ttEntry->depth >= depth) {
             D( m_debug.Increment("NegaMax: TT: Higher Depth") );
@@ -515,7 +523,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
 
     // --------- Move ordering ---------
     // Order moves to maximize search efficiency (hash move, captures, killers, history...)
-    SortMoves(board, moves, Hash::tt, m_heuristics, m_ply);
+    SortMoves(board, moves, hashMove, m_heuristics, m_ply);
 
     // --------- Move loop ---------
     int moveNumber = 0;


### PR DESCRIPTION
**Performance: re-use hash move for sorting**

- Performance: Saves a call to `tt.Probe` in `RateMoves`
- Refactor: separation of concerns, hiding the TT complexity from `RateMoves`.

```
bench 2959622

Elo   | 14.42 +- 16.28 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.18 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 940 W: 324 L: 285 D: 331
Penta | [27, 110, 170, 123, 40]
```