### PR TITLE
enhance: wider recapture extension

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -562,7 +562,6 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
             && move.MoveType() == CAPTURE
             && board.LastMove().MoveType() == CAPTURE
             && move.ToSq() == board.LastMove().ToSq()
-            && move.CapturedType() == board.LastMove().CapturedType()
         ) {
             D( m_debug.Increment("NegaMax: Extension: Recapture") );
             localExtension++;


### PR DESCRIPTION
**Enhance: wider recapture extension**

Activate for **recaptures with any piece**, not only with the same piece. This **INCREASES** the number of extensions. Actually the tree is a lot wider for the same depth (see benchmark).

Interpretation: the engine is hungry for **singular extensions** :)

```
bench 3607186 (previously: 2959622)

Elo   | 13.90 +- 16.00 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.04 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 900 W: 310 L: 274 D: 316
Penta | [30, 84, 186, 120, 30]

Elo   | 28.67 +- 20.28 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 3.08 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 498 W: 169 L: 128 D: 201
Penta | [12, 39, 108, 76, 14]
```