### PR TITLE
simplify: remove razoring

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -20,11 +20,10 @@
 // - Extensions:
 //    - Check extension
 //    - One-reply extension
-//    - Recapture extension in PV nodes
+//    - Recapture extension
 //
 // - Reductions:
 //    - Late Move Reductions: reduce search depth for late non-promising moves
-//    - Razoring: reduce search depth for clearly losing positions
 //
 // - Heuristics:
 //    - History heuristics: reward successful moves in past positions
@@ -449,15 +448,6 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
             D( m_debug.Increment("NegaMax: Pruning: Reverse Futility - Depth " + std::to_string(depth)) );
             return staticEval;
         }
-    }
-
-    // --------- Razoring -------------
-    // Reduction in hopeless nodes (eval << alpha)
-    if(depth == 3 && eval + 1150 <= alpha && !isPV && !extension && Evaluation::AreHeavyPieces(board))
-    {
-        D( m_debug.Increment("NegaMax: Pruning: Razoring") );
-        D( m_debug.Increment("NegaMax: Pruning: Razoring - Depth " + std::to_string(depth)) );
-        depth--;
     }
 
     // --------- Null-move pruning -----------


### PR DESCRIPTION
**Simplify: remove razoring**

Was a relic from the non-LMR HCE days.

```
bench 3607186

Elo   | 1.33 +- 9.29 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.05 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 2610 W: 830 L: 820 D: 960
Penta | [93, 268, 561, 302, 81]

Elo   | 8.81 +- 13.31 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1144 W: 352 L: 323 D: 469
Penta | [27, 124, 243, 149, 29]
```