### PR TITLE
bugfix: killers ply overflow

### DIFF
--- a/include/Heuristics.h
+++ b/include/Heuristics.h
@@ -4,12 +4,12 @@
 #include "MoveGenerator.h"
 
 #include <bit>
+#include <cassert>
 
 class Board;
 class TT;
 struct Heuristics;
 
-const int HEURISTICS_MAX_PLY = 128;
 const int MAX_BONUS = 400;
 constexpr int MAX_HISTORY_VALUE = std::bit_floor( (uint)INFINITE / MAX_BONUS );
 
@@ -28,21 +28,22 @@ public:
         }
     }
     void Update(const Move& killer, int ply) {
+        assert(ply >= 0 && ply < MAX_PLY);
         if(killer != m_killers[ply][0]) {
             m_killers[ply][1] = m_killers[ply][0];
             m_killers[ply][0] = killer;
         }
     }
     Move Primary(int ply) const {
-        assert(ply>=0);
+        assert(ply >= 0 && ply < MAX_PLY);
         return m_killers[ply][0];
     }
     Move Secondary(int ply) const {
-        assert(ply>=0);
+        assert(ply >= 0 && ply < MAX_PLY);
         return m_killers[ply][1];
     }
 private:
-    Move m_killers[HEURISTICS_MAX_PLY][2]; //[PLY][SLOT]
+    Move m_killers[MAX_PLY][2]; //[PLY][SLOT]
 };
 
 class HistoryHeuristics {


### PR DESCRIPTION
**Fix: killers ply overflow**

Remove obsolete variable `HEURISTICS_MAX_PLY = 128`. Replace it by `MAX_PLY` (256).
This fix prevents a possible **overflow in History Killers when reaching plies > 128**.

```
bench 3607186

Elo   | -0.94 +- 9.51 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [-18.00, 0.00]
Games | N: 2598 W: 825 L: 832 D: 941
Penta | [99, 275, 547, 290, 88]
```