### PR TITLE
fix: noeval

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -423,7 +423,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
 
     // --------- Static Evaluation ---------
     // Used in pruning heuristics
-    int eval = 0;
+    int eval = NO_EVAL;
     if(!inCheck) {
         D( m_debug.Increment("NegaMax: Evaluation: 1: Enter") );
         if(ttEval != NO_EVAL) {


### PR DESCRIPTION
Fix: initialize `eval = NO_SCORE` to avoid storing false eval values in TT when in check

```
bench 3607186

Elo   | 0.22 +- 8.67 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 3104 W: 994 L: 992 D: 1118
```