### PR TITLE
enhance: zkey enpassant

### DIFF
--- a/include/ZobristKeys.h
+++ b/include/ZobristKeys.h
@@ -9,9 +9,9 @@ namespace ZobristKeys {
     void Init();
     
     extern u64 m_zkeyColor;
-    extern u64 m_zkeyPieces[2][8][64];
-    extern u64 m_zkeyCastling[2][2];
-    extern u64 m_zkeyEnpassant[8];
+    extern u64 m_zkeyPieces[2][8][64]; //[COLOR][PIECE_TYPE][SQUARE]
+    extern u64 m_zkeyCastling[2][2]; //[COLOR][CASTLING_TYPE]
+    extern u64 m_zkeyEnpassant[8]; //[FILE]
 }
 
 class ZobristKey {

--- a/src/Fen.cpp
+++ b/src/Fen.cpp
@@ -1,4 +1,6 @@
 #include "Fen.h"
+
+#include "Attacks.h"
 #include "Board.h"
 #include "Utils.h"
 
@@ -70,7 +72,12 @@ void Fen::SetPosition(Board& board, std::string fenString) {
     fenStream >> token;
     if(token != "-") {
         int square = board.SquareToIndex(token);
-        board.m_enPassantSquare = SquareBB(square);
+
+        // Is capture possible?
+        Bitboard pawns = board.Piece(board.ActivePlayer(), PAWN);
+        Bitboard epThreats = Attacks::AttacksPawns(board.InactivePlayer(), square);
+        if(epThreats & pawns)
+            board.m_enPassantSquare = SquareBB(square);
     }
 
     //50-move rule

--- a/src/MoveMaker.cpp
+++ b/src/MoveMaker.cpp
@@ -1,4 +1,6 @@
 #include "MoveMaker.h"
+
+#include "Attacks.h"
 #include "Board.h"
 #include "NNUE.h"
 #include "Uci.h"
@@ -42,8 +44,15 @@ void MoveMaker::MakeMove(Board& board, Move move, bool update_nnue) {
     }
     else if(moveType == DOUBLE_PUSH) {
         int squareShift = color == WHITE ? -8 : 8;
-        board.m_enPassantSquare = SquareBB(toSq + squareShift);
-        board.m_zobristKey.UpdateEnpassant(board.m_enPassantSquare);
+        Bitboard epSquare = SquareBB(toSq + squareShift);
+
+        // Is capture possible?
+        const Bitboard epThreats = Attacks::AttacksPawns(board.ActivePlayer(), toSq + squareShift);
+        const Bitboard enemyPawns = board.Piece(board.InactivePlayer(), PAWN);
+        if(epThreats & enemyPawns) {
+            board.m_enPassantSquare = epSquare;
+            board.m_zobristKey.UpdateEnpassant(board.m_enPassantSquare);
+        }
     }
     else if(moveType == ENPASSANT) {
         COLOR enemyColor = board.InactivePlayer();

--- a/src/ZobristKeys.cpp
+++ b/src/ZobristKeys.cpp
@@ -6,7 +6,7 @@
 
 u64 ZobristKeys::m_zkeyColor;
 u64 ZobristKeys::m_zkeyPieces[2][8][64]; //[COLOR][PIECE_TYPE][SQUARE]
-u64 ZobristKeys::m_zkeyCastling[2][2]; //[COLOR][CASTLING_TYPE_SIMPLE]
+u64 ZobristKeys::m_zkeyCastling[2][2]; //[COLOR][CASTLING_TYPE]
 u64 ZobristKeys::m_zkeyEnpassant[8]; //[FILE]
 
 enum CASTLING_TYPE_SIMPLE { CASTLING_KING=0, CASTLING_QUEEN=1 };

--- a/tests/test-ZobristKey.cpp
+++ b/tests/test-ZobristKey.cpp
@@ -65,41 +65,6 @@ TEST_F(ZobristKeyTest, Castling) {
     EXPECT_EQ(initialKeyCastling, boardCastling.ZKey());
 }
 
-TEST_F(ZobristKeyTest, EnPassant_Fen) {
-    board.SetFen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1");
-    u64 keyNo = board.ZKey();
-
-    board.SetFen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1");
-    u64 keyYes = board.ZKey();
-
-    EXPECT_NE(keyNo, keyYes);
-}
-
-TEST_F(ZobristKeyTest, EnPassant_MakeMove) {
-    Board newBoard; //initial position
-    u64 keyBefore = newBoard.ZKey();
-
-    newBoard.MakeMove("e2e4");
-    newBoard.TakeMove();
-
-    u64 keyAfter = newBoard.ZKey();
-
-    EXPECT_EQ(keyBefore, keyAfter);
-}
-
-TEST_F(ZobristKeyTest, SetFen_vs_MakeMove) {
-    // Position after 1. e4 from FEN
-    board.SetFen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1");
-    u64 zkey_fromFen = board.ZKey();
-
-    // Same position after MakeMove
-    Board newBoard;
-    newBoard.MakeMove("e2e4");
-    u64 zkey_fromMakeMove = newBoard.ZKey();
-
-    EXPECT_EQ(zkey_fromFen, zkey_fromMakeMove);
-}
-
 TEST_F(ZobristKeyTest, AfterPerft) {
     board.Perft(3);
     EXPECT_EQ(initialKey, board.ZKey());
@@ -121,4 +86,73 @@ TEST_F(ZobristKeyTest, HashConsistency) {
         u64 zkey2 = board2.ZKey();
         EXPECT_EQ(zkey1, zkey2) << "Hash inconsistent at iteration " << i;
     }
+}
+
+// ======================
+// ===== En-passant =====
+// ======================
+
+// 1.e4. No possible en-passant capture
+// En-passant square should be ignored.
+TEST_F(ZobristKeyTest, EnPassant_Phantom) {
+    board.SetFen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1");
+    u64 keyNo = board.ZKey();
+
+    board.SetFen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1");
+    u64 keyPhantom = board.ZKey();
+
+    EXPECT_EQ(keyNo, keyPhantom);
+}
+
+// e4 with a black pawn on d4. En-passant capture is possible.
+// ZKeys should be different!
+TEST_F(ZobristKeyTest, EnPassant_Real) {
+    board.SetFen("rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1");
+    u64 keyNo = board.ZKey();
+
+    board.SetFen("rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1");
+    u64 keyReal = board.ZKey();
+
+    EXPECT_NE(keyNo, keyReal);
+}
+
+// 1.e4. No possible en-passant capture
+// ZKeys from FEN and MakeMove should be the same. Both ignoring the en-passant square.
+TEST_F(ZobristKeyTest, SetFen_vs_MakeMove_Enpassant_Phantom) {
+    Board newBoard;
+    u64 zkeyInitial = newBoard.ZKey();
+
+    newBoard.MakeMove("e2e4");
+    u64 zkey_fromMakeMove = newBoard.ZKey();
+
+    newBoard.TakeMove();
+    u64 zkeyInitial_fromTakeMove = newBoard.ZKey();
+
+    Board fenBoard;
+    fenBoard.SetFen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1");
+    u64 zkey_fromFen = fenBoard.ZKey();
+
+    EXPECT_EQ(zkeyInitial, zkeyInitial_fromTakeMove);
+    EXPECT_EQ(zkey_fromFen, zkey_fromMakeMove);
+}
+
+// e4 with a black pawn on d4. En-passant capture is possible.
+// ZKeys from FEN and MakeMove should be the same. Both applying the en-passant square.
+TEST_F(ZobristKeyTest, SetFen_vs_MakeMove_Enpassant_Real) {
+    Board newBoard;
+    newBoard.SetFen("rnbqkbnr/ppp1pppp/8/8/3p4/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    u64 zkeyInitial_fromFen = newBoard.ZKey();
+
+    newBoard.MakeMove("e2e4");
+    u64 zkey_fromMakeMove = newBoard.ZKey();
+
+    newBoard.TakeMove();
+    u64 zkeyInitial_fromTakeMove = newBoard.ZKey();
+
+    Board fenBoard;
+    fenBoard.SetFen("rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1");
+    u64 zkey_fromFen = fenBoard.ZKey();
+
+    EXPECT_EQ(zkeyInitial_fromFen, zkeyInitial_fromTakeMove);
+    EXPECT_EQ(zkey_fromFen, zkey_fromMakeMove);
 }


### PR DESCRIPTION
```
Elo   | 8.50 +- 14.24 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1268 W: 438 L: 407 D: 423
Penta | [47, 138, 241, 153, 55]

Elo   | -1.72 +- 6.54 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 4844 W: 1440 L: 1464 D: 1940
Penta | [141, 541, 1069, 543, 128]
```