### PR TITLE
bugfix: age TT blindness + ignore nullmove

### DIFF
--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -44,13 +44,18 @@ void TT::Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth,
 
     const bool replace = older || higherDepth;
     if(replace) {
+        const bool zkeyMatch = (UpperBits<u32>(zkey) == entry->zkey);
+    
         entry->zkey = UpperBits<u32>(zkey);
         entry->score = SafeCastInt16( ScoreToHash(score, ply) );
         entry->eval = SafeCastInt16(eval);
         entry->depth = SafeCastU8(depth);
         entry->type = type;
         entry->age = ttAge;
-        entry->bestMove = bestMove;
+
+        // Do not overwrite a valid bestMove with a null move for the same position
+        if(bestMove.MoveType() != MOVE_TYPE::NULLMOVE || !zkeyMatch)
+            entry->bestMove = bestMove;
     }
 }
 

--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -35,8 +35,11 @@ void TT::Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth,
     u64 index = zkey & m_mask;
     TTEntry* entry = &m_entries[index];
 
+    // Age bitfield protection
+    const u8 ttAge = age & 0x3F;
+
     //Replacement scheme
-    const bool older = age != entry-> age;
+    const bool older = ttAge != entry-> age;
     const bool higherDepth = depth >= entry->depth;
 
     const bool replace = older || higherDepth;
@@ -46,7 +49,7 @@ void TT::Store(u64 zkey, int score, TTENTRY_TYPE type, Move bestMove, int depth,
         entry->eval = SafeCastInt16(eval);
         entry->depth = SafeCastU8(depth);
         entry->type = type;
-        entry->age = age;
+        entry->age = ttAge;
         entry->bestMove = bestMove;
     }
 }

--- a/tests/test-Hash.cpp
+++ b/tests/test-Hash.cpp
@@ -42,7 +42,7 @@ TEST_F(TT_Test, NormalScoreUnchanged) {
 
 // Age 6-bit bitfield behaves correctly after overflow (> 63)
 TEST_F(TT_Test, AgeBitfieldProtection) {
-    // Reach searchCount 64. Store a high-depth entry
+    // SearchCount reached 64. Store a high-depth entry
     tt.Store(zkey, normalScore, TTENTRY_TYPE::EXACT, Move(), /*depth=*/21, /*ply=*/0, /*age=*/64);
 
     // Same search. Try to store the same position with a lower-depth. Should NOT overwrite!
@@ -52,4 +52,15 @@ TEST_F(TT_Test, AgeBitfieldProtection) {
     ASSERT_NE(entry, nullptr);
 
     EXPECT_EQ(entry->depth, 21);
+}
+
+TEST_F(TT_Test, NullBestMoveIgnored) {
+    Move move = Move(G1, F3, KNIGHT, MOVE_TYPE::NORMAL);
+    tt.Store(zkey, normalScore, TTENTRY_TYPE::EXACT, move, /*depth=*/1, /*ply=*/0, /*age=*/0);
+    tt.Store(zkey, normalScore, TTENTRY_TYPE::EXACT, Move(), /*depth=*/2, /*ply=*/0, /*age=*/0);
+
+    TTEntry* entry = tt.Probe(zkey);
+    ASSERT_NE(entry, nullptr);
+
+    EXPECT_EQ(entry->bestMove, move);
 }

--- a/tests/test-Hash.cpp
+++ b/tests/test-Hash.cpp
@@ -4,28 +4,52 @@
 using namespace TestCommon;
 #include <gtest/gtest.h>
 
-TEST(TT, MateScoreAdjustment) {
+class TT_Test : public ::testing::Test {
+protected:
     TT tt;
-    tt.SetSize(1);
-    u64 zkey = 0x123456789ABCDEF0;
+    u64 zkey;
+    int normalScore;
 
-    // Mate scores get adjusted by ply
+    void SetUp() override {
+        tt.SetSize(1);
+        zkey = 0x123456789ABCDEF0;
+        normalScore = 150;
+    }
+};
+
+// Mate scores get adjusted by ply
+TEST_F(TT_Test, MateScoreAdjustment) {
     int mateIn5 = MATESCORE_MAX - 5;
     tt.Store(zkey, mateIn5, TTENTRY_TYPE::EXACT, Move(), 10, /*ply=*/3, 0);
+
     TTEntry* entry = tt.Probe(zkey);
+    ASSERT_NE(entry, nullptr);
+
     EXPECT_EQ(tt.ScoreFromHash(entry->score, 3), mateIn5);
     EXPECT_EQ(tt.ScoreFromHash(entry->score, 0), MATESCORE_MAX - 2);
 }
 
-TEST(TT, NormalScoreUnchanged) {
-    TT tt;
-    tt.SetSize(1);
-    u64 zkey = 0xABCDEF0123456789;
-
-    // Normal scores should NOT be adjusted
-    int normalScore = 150;
+// Normal scores should NOT be adjusted
+TEST_F(TT_Test, NormalScoreUnchanged) {
     tt.Store(zkey, normalScore, TTENTRY_TYPE::EXACT, Move(), 10, /*ply=*/5, 0);
+
     TTEntry* entry = tt.Probe(zkey);
+    ASSERT_NE(entry, nullptr);
+
     EXPECT_EQ(tt.ScoreFromHash(entry->score, 0), normalScore);
     EXPECT_EQ(tt.ScoreFromHash(entry->score, 10), normalScore);
+}
+
+// Age 6-bit bitfield behaves correctly after overflow (> 63)
+TEST_F(TT_Test, AgeBitfieldProtection) {
+    // Reach searchCount 64. Store a high-depth entry
+    tt.Store(zkey, normalScore, TTENTRY_TYPE::EXACT, Move(), /*depth=*/21, /*ply=*/0, /*age=*/64);
+
+    // Same search. Try to store the same position with a lower-depth. Should NOT overwrite!
+    tt.Store(zkey, normalScore, TTENTRY_TYPE::EXACT, Move(), /*depth=*/1, /*ply=*/0, /*age=*/64);
+
+    TTEntry* entry = tt.Probe(zkey);
+    ASSERT_NE(entry, nullptr);
+
+    EXPECT_EQ(entry->depth, 21);
 }


### PR DESCRIPTION
- **Fix**: The engine **played worse after move 64** (or 32 in ponder)!
Detail: `age` is a 6-bit bitfield (0-63) in a TT entry. When reached 64 it takes a value of 0, as expected. But when storing the new entry it was compared with an integer, causing the comparison `age != searchCount` to be always true. The side effect was that **every entry** gets replaced after 64 searches!

- **Fix**: The engine was **replacing valid bestMoves with null moves** in the TT!
Detail: _Null moves_ can be generated in Null-Move Pruning (NMP) or Syzygy endgame tablebases. Even if searched at a higher depth, they should **never replace** a valid bestMove entry from a past search (as long as the position is the same). That move can be used for better move ordering.

```
bench 3601894 (previous: 3607186)

Elo   | 1.90 +- 9.66 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 2378 W: 778 L: 765 D: 835
Penta | [64, 281, 510, 246, 88]

Elo   | 9.34 +- 13.87 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=64MB
LLR   | 3.01 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1154 W: 364 L: 333 D: 457
Penta | [34, 120, 241, 145, 37]
```