### PR TITLE
chore: version 1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 project(Casanchess 
-    VERSION 1.0.0
+    VERSION 1.1.0
     LANGUAGES CXX
 )
 

--- a/README.md
+++ b/README.md
@@ -1,59 +1,59 @@
-# Casanchess
-[![Build Status](https://github.com/casanche/casanchess/actions/workflows/tests.yml/badge.svg)](https://github.com/casanche/casanchess/actions/workflows/tests.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+<div align="center">
 
-Open-source [UCI](http://wbec-ridderkerk.nl/html/UCIProtocol.html)-compatible chess engine written from scratch in modern C++.
+<img src="https://github.com/user-attachments/assets/b3025cbb-8ed8-477e-83be-730cd8edfdd5" height="200" alt="Casanchess Logo">
 
-The project's ambition is to achieve high playing strength while maintaining a clean, well-structured, and understandable codebase.
+**UCI chess engine written in C++23 with NNUE evaluation**
 
-The NNUE evaluation is trained on millions of chess positions, generated from self-play games and randomly created FENs. Each position was evaluated at depth 7 from its own evaluation function.
-
-## Play it on Lichess!
-Challenge the last version of the engine on:
-<p align="center">
-  <a href="https://lichess.org/@/Casanchess-NNUE">
-    <strong>Play against Casanchess-NNUE</strong>
-  </a>
+<p>
+  <a href="https://github.com/casanche/casanchess/actions/workflows/tests.yml"><img src="https://github.com/casanche/casanchess/actions/workflows/tests.yml/badge.svg?branch=master" alt="Build and Test"></a>&nbsp;
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>&nbsp;
+  <a href="https://lichess.org/@/Casanchess-NNUE"><img src="https://img.shields.io/badge/Lichess-Play_vs_Casanchess_bot-d65108?logo=lichess&logoColor=white" alt="Play on Lichess"></a>
 </p>
+
+</div>
+
+**Casanchess** aims to balance high playing strength with a clean and highly readable codebase.
+
+Its NNUE evaluation is trained on millions of self-play and random positions, using a custom datagen and trainer.
+
+The engine is designed to be both a strong opponent and an accessible resource for anyone interested in modern chess programming.
+
+## Design philosophy
+* ***Clean code:*** The primary goal is to increase strength, keeping the code elegant and easy to follow without sacrificing too much performance.
+* ***Originality:*** Another principle is to remain original. Every PR has a clear reason and meaning. While the engine integrates standard and well-tested chess programming techniques, copying the implementation of other engines is actively avoided.
+* ***Incremental progress:*** Improvements are made iteratively using strict SPRT. Development takes time since the hardware for testing is limited! But the focus remains on organic growth.
 
 ## Getting started
 The easiest way is to download the latest compiled release binaries from the **[Releases](https://github.com/casanche/casanchess/releases)** page.
+*Requires a CPU with AVX2 support.*
 
 Alternatively, you could compile the source code yourself using a C++23 compliant compiler:
-```sh
+```bash
 git clone https://github.com/casanche/casanchess.git
 cd casanchess
 
-mkdir build && cd build
-cmake ..
-cmake --build . --parallel
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release --parallel
 ```
 
-### Configuration
-For the NNUE evaluation to work, the `.nnue` file must be accessible:
+## UCI options
+* **``ClearHash``**: Reset the transposition table entries.
+* **``Hash``**: Transposition table size in MB. Default: 16MB
+* **``NNUE_Path``**: Absolute or relative path to the NNUE file.
+* **``Ponder``**: Allows the engine to think on opponent's time.
 
-* **Default**: Place the `.nnue` file in the working directory. Usually the same directory as the `casanchess` executable.
-* **Custom path**: if the `.nnue` file is in a different location, set its path via the `NNUE_Path` UCI option.
+For the NNUE evaluation to work, the `.nnue` file must be accessible.
+By default, you should put the network file in the working directory (usually the same directory as the `casanchess` executable).
+Alternatively, you can explicitly set its location using the `NNUE_Path` UCI option.
 
-The following UCI options are available:
-
-* **``Hash``**: the transposition table size in MB. Default: 16MB
-* **``Ponder``**: allows the engine to think on the opponent's time. Off by default.
-* **``ClearHash``**: clears the transposition table.
-* **``ClassicalEval``**: turn on to switch to the classical evaluation without NNUE. Off by default.
-* **``NNUE_Path``**: Path to the NNUE file.
-
-## Future roadmap
-* Multi-thread implementation
+## Contributing
+Contributions are more than welcome. Whether it's reporting bugs, suggesting new features, testing or improving the code, every contribution is appreciated.
+Feel free to open an issue!
 
 ## Special thanks
-This project definitely would not be possible without the amazing chess programming community and the knowledge they openly share.
-And to the many authors of chess engines, especially those with an inclination towards originality: keep up the work!
+The engine has evolved significantly since its early beginnings around 2018.
+Projects like [Winglet](https://web.archive.org/web/20120621100214/http://www.sluijten.com/winglet/) and [ShallowBlue](https://github.com/GunshipPenguin/shallow-blue) introduced me to bitboards and the very first chess-programming concepts to get started, as well as [cerebrum](https://github.com/david-carteau/cerebrum) for its simple NNUE implementation.
 
-Contributions are welcome! Whether it's reporting bugs, suggesting new features, or improving the code, every contribution is appreciated.
+Big thanks to the always amazing chess programming community. The knowledge openly shared on the [Talkchess.com](http://talkchess.com) forums and the [Chess Programming Wiki](https://www.chessprogramming.org) has been an essential resource throughout this journey.
 
-Thanks to:
-- [Talkchess.com](http://talkchess.com) forum. For the countless hours reading technical stuff.
-- [Chess programming wiki](https://www.chessprogramming.org). Always an amazing resource of learning.
-- [ShallowBlue](https://github.com/GunshipPenguin/shallow-blue). Clean C++ engine that provided initial inspiration.
-- [cerebrum](https://github.com/david-carteau/cerebrum). Nice and simple NNUE implementation.
+Finally, to the many authors of chess engines, especially those who prioritize originality and independent development: keep up the great work!

--- a/src/Uci.cpp
+++ b/src/Uci.cpp
@@ -18,7 +18,7 @@ namespace {
     const std::string ENGINE_NAME = "Casanchess";
     const std::string AUTHOR = "Carlos Sanchez Mayordomo";
     const std::string VERSION_MAJOR = "1";
-    const std::string VERSION_MINOR = "0";
+    const std::string VERSION_MINOR = "1";
     const std::string VERSION_PATCH = "0";
 }
 


### PR DESCRIPTION
# **Version 1.1 - Detailed changelog**

## ✨ Features

- **[🛡️]** Full support for Pondering (`ponder` / `ponderhit`), allowing the engine to think during the opponent's turn (#97).

## 📊 Interface

- **[🛡️]** Display aspiration window bounds (`lowerbound` / `upperbound`) and live PV updates for unfinished search depths in UCI output (#76).
- **[🛡️]** Update search metrics (`time`, `nodes`, `nps`, `tbhits`) after each root move in UCI live output (#70).
- **[🛡️]** Relocate node counting (`m_nodes++`) to the start of search functions to accurately report TT hits and cutoffs (#59).
- **[🛡️]** Enforce thread-safe search stops before processing major UCI input commands (#89).

## 📈 Enhancements

- **[🎯]** Use Evaluation Cache in NegaMax search and store (and use) 16-bit `ttEval` inside Transposition Table (#88).
- **[🎯]** Enhance Quiescence Search (QS) move ordering by probing TT before evaluating stand-pat and prioritizing the hash move (#68, #75).
- **[📈]** Extend wider recapture extensions to any capturing piece (previously same piece type). Partially filling the gap of the absence of singular extensions (#94).
- **[📈]** Update and return the best move found so far during incomplete search depths, ensuring deeper moves are played on time cutoffs (#76).
- **[📈]** Improve time management with smart allocation (1/3 time for single legal moves, 1/2 time after `ponderhit`, increment loss protection), 50ms `TIME_OVERHEAD`, and 1024-node check intervals (#87, #91).

## ⚡ Performance

- **[🎯]** Quantize NNUE evaluation to 16-bit integer arithmetic (~25% speedup) (#86).
- **[📈]** Optimize NNUE by maintaining accumulators per ply to avoid `memcpy` and skipping full updates on king moves within the same bucket (#83, #84).
- **[📈]** Optimize move ordering by re-using the hash move in `RateMoves` to avoid extra TT probes (#93).
- **[📈]** Relax TT probing by using stored `ttEval` regardless of search depth (#92).
- **[📈]** Overhaul repetition draw detection to return a draw after the first repetition, strictly respect the 50-move rule, and catch 2-fold root repetitions earlier (#62, #79).
- **[📈]** Optimize Quiescence Search (QS) by removing redundant stalemate checks when no tactical moves remain (#64).

## 🐛 Bugfixes

- **[🛡️]** Fix segfault when receiving the UCI `quit` command during search by awaiting search thread completion (#87).
- **[📈]** Rewrite Static Exchange Evaluation (SEE) using dynamic occupancy bitboards to fix X-Ray blind spots behind friendly pieces, correctly score king recaptures, and add support for promotions and en-passant (#61, #66, #80).
- **[📈]** Fix TT entry replacement issues by correcting 6-bit age comparisons past move 64, preventing null moves from overwriting valid bestMoves, and initializing in-check eval to `NO_SCORE` (#98, #100).
- **[📈]** Fix missing en-passant move generation when the capture blocks an incoming check (#82).
- **[📈]** Prevent TT and PV state corruption upon reaching time/node limits via immediate stack unwinding (`m_stop`) and add QS termination checks (#59).
- **[📈]** Fix false TT `EXACT` bound assignments caused by Mate Distance Pruning by evaluating `bestScore` against `alphaOriginal` in NegaMax (#60).
- **[🛡️]** Fix illegal move outputs (e.g. `0000`) during ultra-short searches like `go nodes 1` when depth 1 does not complete (#76).
- **[🛡️]** Prevent out-of-bounds stack access, killer move array overflow, and PV array overflow by enforcing `MAX_PLY` (256) bounds (#73, #89, #96).
- **[🛡️]** Ensure fail-soft consistency in `RootMax` algorithm to match NegaMax (#74).
- **[🛡️]** Fix intermittent Windows segfaults caused by SIMD stack misalignment (`__m256i`) (#90).

## 🧹 Simplifications & Refactors

- **[📈]** Streamline Quiescence Search (QS) pruning: remove static SEE pruning, eliminate conservative `bestScore` updates in delta pruning, and simplify negative SEE capture pruning by removing `DELTA_MARGIN_RISKY` (#60, #67, #69).
- **[📈]** Remove obsolete razoring pruning logic (#95).
- **[🛡️]** Lean down `Search.cpp` by extracting time management and search termination logic into `SearchLimits.cpp`, and isolating I/O formatting into `UCI.cpp` (#89).
- **[🛡️]** Modernize codebase (Iteration 1): convert `typedef` to `using`, use `<limits>`, `constexpr`, and eliminate trivial macros (#78).

## ⚙️ CI & Automation

- Add a UCI smoke test, unify build/test workflows, and add Windows 2025 Debug CI checks (#63, #81, #90).

<br>

📌 **Legend:**
- **[🎯]** Passed **improvement** SPRT. Measured Elo gain.
- **[📈]** Passed **no-regression** SPRT. Potential/theoretical Elo gain.
- **[🛡️]** Passed **no-regression** SPRT. Stability, fix, or protocol compliance (no Elo change expected).

---

# Release notes

Full **pondering support**, **~25% speedup** after 16-bit NNUE quantization, richer **live UCI output**, refinements to time management and search, and many bugfixes.

✨ **Features**
* **Ponder support:** enable `ponder` / `ponderhit` capabilities. Previous version was crashing sometimes.
* **Rich live UCI output:** improve real-time UCI output with aspiration window bounds (`lowerbound` / `upperbound`), PV updates for incomplete search depths, and accurate live metrics (`nps`, `nodes`, `tbhits`). Also change the "nodes" definition: now defined as entering the search function, not only after a move is made.

⚡ **Enhancements and performance**
* **16-bit quantized NNUE (~25% Speedup):** quantize neural network and evaluate using 16-bit integer arithmetic.
* **Rewrite SEE:** use dynamic occupancy bitboards, eliminating X-Ray blind spots behind friendly pieces and correctly scoring king recaptures, promotions and en-passant.
* **Smart time management:** improve time allocation logic. Avoid timeouts in scenarios when *remaining time < time increment*, add 50ms time overhead, and other small tweaks.
* **Search refinements:** use more efficiently the hash move and the evaluation cache, and introduce a wider recapture extension (this means the engine is hungry for singular extensions!).

🛡️ **Fixes and stability**
* **Fun fact:** ensure the engine always returns a valid move, not '0000', on ultra-short searches (`go nodes 1`).
* **Even funnier fact:** the engine was not generating en-passant moves that block checks! A type of move so uncommon that perft passed, bench remains unchanged, and Elo increase is within measure bounds (#82).
* **Crash fixes:** solve crashes when receiving the UCI `quit` command mid-search, and intermittent crashes on Windows build (SIMD stack misalignment segfaults).
* **TT and deep search stability**: solve silent TT corruption when stopped mid-search and past move 64 (`age` comparison), and enforce `MAX_PLY` (256) bounds to avoid overflows.
* **Thread-safe UCI:** guarantee thread-safe search stops before processing major UCI commands for a smoother GUI interaction.

**Detailed changelog**: #101
**Diff**: https://github.com/casanche/casanchess/compare/v1.0...v1.1

### v1.1 vs v1.0
```
Elo   | 121.51 +- 5.28 (95%)
Conf  | 7.0+0.07s Threads=1 Hash=16MB
Games | N: 10002 W: 4702 L: 1340 D: 3960
Penta | [75, 513, 1440, 1921, 1052]

Elo   | 112.60 +- 7.53 (95%)
Conf  | 30.0+0.30s Threads=1 Hash=64MB
Games | N: 4004 W: 1683 L: 429 D: 1892
Penta | [20, 177, 648, 843, 314]
```

ELO estimation in CCRL list: around **2890**.

---

# New logo
Tribute to [Francesc Vicent](https://en.wikipedia.org/wiki/Francesc_Vicent), who in his 1495 treatise *Libre dels jochs partits dels schacs en nombre de 100* founded modern chess by introducing queen and bishop moves, making the queen the most powerful chess piece. In ancient chess they only advanced one square.
Color palette: orange and yellow, featuring mediterranean mood and Fallas.
_Generated with AI_

<p align="center">
  <img src="https://github.com/user-attachments/assets/b3025cbb-8ed8-477e-83be-730cd8edfdd5" width="400" alt="Casanchess Logo">
</p>
