### PR TITLE
fix: release v1.1.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,15 @@
 name: Build and Test
 
+env:
+  LLVM_MINGW_VERSION: "20260826"
+
 on:
   push:
     branches: [ "master", "*/**" ]
 
 jobs:
   build_and_test:
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -14,31 +18,64 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # RELEASE - Linux
-          - os: ubuntu-latest
+          # Linux
+          - os: ubuntu-24.04
+            name: Linux Release (GCC)
             build_type: Release
             compiler: g++
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
+            name: Linux Release (Clang)
             build_type: Release
             compiler: clang++
-          # RELEASE - Windows
-          - os: windows-latest
+          - os: ubuntu-24.04
+            name: Linux Debug (GCC)
+            build_type: Debug
+            compiler: g++
+          # Windows
+          - os: windows-2025
+            name: Windows Release (MSVC)
             build_type: Release
             compiler: cl
           - os: windows-2025
+            name: Windows Release (clang-cl)
             build_type: Release
-            compiler: g++
-          # DEBUG - Windows
+            compiler: clang-cl
+            c_compiler: clang-cl
+            toolchain: clang-cl
           - os: windows-2025
+            name: Windows Release (LLVM-MinGW)
+            build_type: Release
+            compiler: x86_64-w64-mingw32-clang++
+            c_compiler: x86_64-w64-mingw32-clang
+            toolchain: llvm-mingw
+          - os: windows-2025
+            name: Windows Debug (clang-cl)
             build_type: Debug
-            compiler: g++
-          # DEBUG - Linux
-          - os: ubuntu-latest
-            build_type: Debug
-            compiler: g++
+            compiler: clang-cl
+            c_compiler: clang-cl
+            toolchain: clang-cl
     
     steps:
     - uses: actions/checkout@v7
+
+    - name: Set up MSVC environment for clang-cl
+      if: ${{ matrix.toolchain == 'clang-cl' }}
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x64
+
+    - name: Set up LLVM-MinGW
+      if: ${{ matrix.toolchain == 'llvm-mingw' }}
+      shell: pwsh
+      run: |
+        $archive = Join-Path $env:RUNNER_TEMP "llvm-mingw.zip"
+        $destination = Join-Path $env:RUNNER_TEMP "llvm-mingw"
+        $package = "llvm-mingw-$env:LLVM_MINGW_VERSION-ucrt-x86_64"
+        $url = "https://github.com/mstorsjo/llvm-mingw/releases/download/$env:LLVM_MINGW_VERSION/$package.zip"
+
+        Invoke-WebRequest -Uri $url -OutFile $archive
+        Expand-Archive -Path $archive -DestinationPath $destination
+        (Join-Path $destination "$package/bin") | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Setup dependencies (Linux)
       if: ${{ runner.os == 'Linux' }}
@@ -53,17 +90,20 @@ jobs:
       run: >
         cmake -B build
         -S .
-        ${{ runner.os == 'Windows' && matrix.compiler == 'g++' && '-G Ninja' || '' }}
+        ${{ runner.os == 'Windows' && matrix.compiler != 'cl' && '-G Ninja' || '' }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
+        ${{ matrix.c_compiler && format('-DCMAKE_C_COMPILER={0}', matrix.c_compiler) || '' }}
+        ${{ matrix.toolchain == 'clang-cl' && '-DCMAKE_LINKER_TYPE=LLD' || '' }}
         -DENABLE_STATIC=ON
+        -DENABLE_LTO=ON
         -DBUILD_TESTS=ON
         -DBUILD_TESTS_EXTRA=ON
         -DBUILD_EXECUTABLES_EXTRA=ON
-        
+
     - name: Build
       run: cmake --build build --config ${{ matrix.build_type }} --parallel
-        
+
     - name: Fix permissions (Linux)
       if: ${{ runner.os == 'Linux' }}
       working-directory: ./build
@@ -129,6 +169,7 @@ jobs:
         "
 
     - name: Upload artifacts
+      if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.compiler }}-engine

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 project(Casanchess 
-    VERSION 1.1.0
+    VERSION 1.1.2
     LANGUAGES CXX
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,15 +33,23 @@ endif()
 # =============================================================================
 # Compiler Configuration
 # =============================================================================
-if(MSVC)
-    message(STATUS "Compiler: MSVC")
+if(MSVC OR CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+    message(STATUS "Compiler frontend: MSVC-compatible")
+    set(ARCH_FLAGS /arch:AVX2)
     set(COMPILER_OPTIONS
-        /W4 /EHsc /arch:AVX2 /MP
+        /W4 /EHsc ${ARCH_FLAGS}
         $<$<CONFIG:RELEASE>:/O2 /fp:fast /DNDEBUG>
         $<$<CONFIG:RELWITHDEBINFO>:/O2 /fp:fast /DNDEBUG /Zi>
         $<$<CONFIG:DEBUG>:/Od /DDEBUG /Zi>
     )
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL" CACHE STRING "" FORCE)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        list(APPEND COMPILER_OPTIONS /MP)
+    endif()
+    if(ENABLE_STATIC)
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>" CACHE STRING "" FORCE)
+    else()
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL" CACHE STRING "" FORCE)
+    endif()
 else()
     set(WARNING_FLAGS -Wall -Wextra -Wshadow)
     set(ARCH_FLAGS -march=haswell -mtune=generic)
@@ -57,26 +65,27 @@ endif()
 # =============================================================================
 # Linker Configuration
 # =============================================================================
-if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-
-    # IPO/LTO Configuration
-    if(ENABLE_LTO)
-        include(CheckIPOSupported)
-        check_ipo_supported(RESULT ipo_supported OUTPUT ipo_error)
-        if(ipo_supported)
-            message(STATUS "IPO/LTO enabled")
-            set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
-        else()
-            message(STATUS "IPO/LTO not supported: ${ipo_error}")
-        endif()
+# IPO/LTO Configuration
+if(ENABLE_LTO)
+    if(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        set(CMAKE_CXX_COMPILE_OPTIONS_IPO "-flto=full")
     endif()
 
-    # Static Compilation
-    if(ENABLE_STATIC AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        message(STATUS "STATIC linking mode enabled")
-        set(LINK_FLAGS ${LINK_FLAGS} -static)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT ipo_supported OUTPUT ipo_error)
+    if(ipo_supported)
+        message(STATUS "IPO/LTO enabled for Release builds")
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO TRUE)
+    else()
+        message(STATUS "IPO/LTO not supported: ${ipo_error}")
     endif()
-    
+endif()
+
+# Static GNU/MinGW builds
+if(ENABLE_STATIC AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug" AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR MINGW))
+    message(STATUS "STATIC linking mode enabled")
+    list(APPEND LINK_FLAGS -static)
 endif()
 
 # =============================================================================
@@ -98,8 +107,10 @@ if(BUILD_TESTS)
     FetchContent_MakeAvailable(googletest)
     
     # Disable LTO for GoogleTest targets
-    set_property(TARGET gtest PROPERTY INTERPROCEDURAL_OPTIMIZATION FALSE)
-    set_property(TARGET gtest_main PROPERTY INTERPROCEDURAL_OPTIMIZATION FALSE)
+    set_target_properties(gtest gtest_main PROPERTIES
+        INTERPROCEDURAL_OPTIMIZATION_RELEASE FALSE
+        INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO FALSE
+    )
 endif()
 
 # Fathom
@@ -108,6 +119,7 @@ set_source_files_properties(
     external/fathom/src/tbprobe.c
     PROPERTIES LANGUAGE CXX
 )
+target_compile_options(fathom PRIVATE ${ARCH_FLAGS})
 target_include_directories(fathom PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/fathom/src>
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ set(ENGINE_SOURCES
     src/Board.cpp
     src/Constants.cpp
     src/Debug.cpp
+    src/Engine.cpp
     src/Evaluation.cpp
     src/Fen.cpp
     src/Hash.cpp

--- a/external/fathom/src/stdendian.h
+++ b/external/fathom/src/stdendian.h
@@ -113,10 +113,10 @@
 #define __ENDIAN_DEFINED        1
 #endif /* sun */
 
-/* Windows (also Emscripten) */
-#if defined(_WIN32) || defined(_MSC_VER) || defined(__EMSCRIPTEN__)
+/* Windows */
 /* assumes all Microsoft targets are little endian. */
 /* Emscripten (emcc) also currently assumes little endian. */
+#if defined(_WIN32) || defined(_MSC_VER) || defined(__EMSCRIPTEN__)
 #define _LITTLE_ENDIAN          1234
 #define _BIG_ENDIAN             4321
 #define _BYTE_ORDER             _LITTLE_ENDIAN
@@ -227,7 +227,7 @@ inline uint64_t bswap64(uint64_t x) {
 #define le16toh(x)              ((uint16_t)(x))
 
 #define htobe32(x)              bswap32((x))
-#define htole32(x)              ((uint32_t((x))
+#define htole32(x)              ((uint32_t)(x))
 #define be32toh(x)              bswap32((x))
 #define le32toh(x)              ((uint32_t)(x))
 

--- a/external/fathom/src/tbprobe.c
+++ b/external/fathom/src/tbprobe.c
@@ -261,12 +261,23 @@ static uint16_t from_be_u16(const uint16_t input) {
 
 inline static uint32_t read_le_u32(void *p)
 {
-  return from_le_u32(*(uint32_t *)p);
+  // input may be unaligned, so read into stack allocated
+  // buffer, which should be aligned
+  // (prevents runtime errors from glibc)
+  unsigned char buffer[4];
+  memcpy(buffer, p, 4);
+  return from_le_u32(*(uint32_t *)buffer);
 }
 
 inline static uint16_t read_le_u16(void *p)
 {
-  return from_le_u16(*(uint16_t *)p);
+  // input may be unaligned, so read into stack allocated
+  // buffer, which should be aligned
+  // (prevents runtime errors from glibc)
+  unsigned char buffer[2];
+  buffer[0] = *((unsigned char*)p);
+  buffer[1] = *(((unsigned char*)p)+1);
+  return from_le_u16(*(uint16_t *)buffer);
 }
 
 static size_t file_size(FD fd) {
@@ -896,8 +907,25 @@ bool tb_init(const char *path)
   TB_MaxCardinality = TB_MaxCardinalityDTM = 0;
 
   if (!pieceEntry) {
+#if defined(__cplusplus) && (__cplusplus >= 202002L)
+    /* Fix crash with -std=c++20 by being consistent with BaseEntry initialization:
+
+        #if __cplusplus >= 202002L
+            atomic<bool> ready[3]{false, false, false};
+        #else
+            ...
+
+        C++ initialization does not work with malloc.
+        Also: with new, if the allocation fails we get std::bad_alloc exception,
+        which is better library behavior than just calling exit.
+     */
+
+    pieceEntry = new PieceEntry[TB_MAX_PIECE]();
+    pawnEntry = new PawnEntry[TB_MAX_PAWN]();
+#else
     pieceEntry = (struct PieceEntry*)malloc(TB_MAX_PIECE * sizeof(*pieceEntry));
     pawnEntry = (struct PawnEntry*)malloc(TB_MAX_PAWN * sizeof(*pawnEntry));
+#endif
     if (!pieceEntry || !pawnEntry) {
       fprintf(stderr, "Out of memory.\n");
       exit(EXIT_FAILURE);
@@ -1018,8 +1046,15 @@ finished:
 void tb_free(void)
 {
   tb_init("");
+#if defined __cplusplus && __cplusplus >= 202002L
+  delete[] pieceEntry;
+  delete[] pawnEntry;
+#else
   free(pieceEntry);
   free(pawnEntry);
+#endif
+  pieceEntry = NULL;
+  pawnEntry = NULL;
 }
 
 static const int8_t OffDiag[] = {

--- a/external/fathom/src/tbprobe.h
+++ b/external/fathom/src/tbprobe.h
@@ -169,7 +169,7 @@ extern unsigned TB_LARGEST;
  *   The tablebase PATH string.
  *
  * RETURN:
- * - true=succes, false=failed.  The TB_LARGEST global will also be
+ * - true=success, false=failed.  The TB_LARGEST global will also be
  *   initialized.  If no tablebase files are found, then `true' is returned
  *   and TB_LARGEST is set to zero.
  */

--- a/include/Engine.h
+++ b/include/Engine.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Board.h"
+#include "Hash.h"
+#include "Search.h"
+
+struct Engine {
+    Engine();
+
+    void NewGame();
+    void StartSearch(const UCI_Limits& limits);
+    void StopSearch();
+
+    TT tt;
+    Search search;
+    Board board;
+};

--- a/include/Interface.h
+++ b/include/Interface.h
@@ -1,21 +1,19 @@
 #pragma once
 
-#include "Board.h"
-#include "Hash.h"
-#include "Search.h"
-
+#include <memory>
 #include <string>
+
+struct Engine;
 
 class Interface {
 public:
     Interface();
-    void NewGame();
+    ~Interface();
+
     void Print();
     void Start(std::string fenString = "");
 private:
     void PrintWelcome();
 
-    TT m_tt;
-    Search m_search;
-    Board m_board;
+    std::unique_ptr<Engine> m_engine;
 };

--- a/include/Uci.h
+++ b/include/Uci.h
@@ -33,12 +33,10 @@ private:
     void Position(std::istringstream &stream);
     void SetOption(std::istringstream &stream);
     
-    void StartSearch();
+    void StartSearch(UCI_Limits limits);
 
     void ShowHashMoves();
     void StopAndJoin();
-
-    UCI_Limits m_limits;
     
     TT m_tt;
     Search m_search;

--- a/include/Uci.h
+++ b/include/Uci.h
@@ -1,11 +1,14 @@
 #pragma once
 
-#include "Board.h"
+#include "Hash.h"
 #include "Search.h"
 #include "SearchLimits.h"
 
+#include <memory>
 #include <sstream>
 #include <thread>
+
+struct Engine;
 
 inline bool UCI_PONDER = false;
 inline bool UCI_CLASSICAL_EVAL = false;
@@ -33,14 +36,9 @@ private:
     void Position(std::istringstream &stream);
     void SetOption(std::istringstream &stream);
     
-    void StartSearch(UCI_Limits limits);
-
     void ShowHashMoves();
     void StopAndJoin();
     
-    TT m_tt;
-    Search m_search;
-    Board m_board;
-
+    std::unique_ptr<Engine> m_engine;
     std::thread m_searchThread;
 };

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -1,0 +1,21 @@
+#include "Engine.h"
+
+Engine::Engine() :
+    tt(),
+    search(tt),
+    board()
+{}
+
+void Engine::NewGame() {
+    tt.Clear();
+    search.ClearSearch(true);
+    board.Init();
+}
+
+void Engine::StartSearch(const UCI_Limits& limits) {
+    search.IterativeDeepening(board, limits);
+}
+
+void Engine::StopSearch() {
+    search.Stop();
+}

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -1,34 +1,33 @@
 #include "Interface.h"
 
+#include "Engine.h"
 #include "MoveGenerator.h"
-#include "Search.h"
 
 #include <iostream>
 
 const int fixedNodes = 250000;
 const std::string prefix = ">";
 
-Interface::Interface() : m_tt(), m_search(m_tt), m_board() {
-    NewGame();
+Interface::Interface() : m_engine(std::make_unique<Engine>()) {
+    m_engine->NewGame();
 }
 
-void Interface::NewGame() {
-    m_tt.Clear();
-
-    m_board.Init();
-}
+Interface::~Interface() = default;
 
 void Interface::Print() {
-    m_board.Print();
+    m_engine->board.Print();
 }
 
 void Interface::Start(std::string fenString) {
+    Board& board = m_engine->board;
+    Search& search = m_engine->search;
+
     PrintWelcome();
 
     if(fenString == "") {
-        NewGame();
+        m_engine->NewGame();
     } else {
-        m_board.SetFen(fenString);
+        board.SetFen(fenString);
     }
 
     std::string input;
@@ -46,17 +45,17 @@ void Interface::Start(std::string fenString) {
         //Set the board position from a fen string
         else if(input.find("fen") != std::string::npos) {
             input.erase(0, 4); //pos 0, size 4
-            m_board.SetFen(input);
+            board.SetFen(input);
         }
 
         //Random move
         else if(input == "random") {
-            MoveList moves = MoveGenerator::GenerateMoves(m_board);
+            MoveList moves = MoveGenerator::GenerateMoves(board);
 
             if( !moves.empty() ) {
-                m_board.MakeMove( MoveGenerator::RandomMove(moves) );
+                board.MakeMove( MoveGenerator::RandomMove(moves) );
             } else {
-                if( m_board.IsCheck() ) {
+                if( board.IsCheck() ) {
                     P("Checkmate!!!")
                 } else {
                     P("Stalemate...")
@@ -67,23 +66,23 @@ void Interface::Start(std::string fenString) {
 
         //Think and make a move
         else if(input == "think" || input == "t") {
-            m_search.IterativeDeepening(m_board, UCI_Limits::FixNodes(fixedNodes));
-            m_search.MakeMove(m_board);
+            search.IterativeDeepening(board, UCI_Limits::FixNodes(fixedNodes));
+            search.MakeMove(board);
         }
 
         //Show the list of moves
         else if(input == "moves") {
-            m_board.ShowMoves();
+            board.ShowMoves();
         }
 
         //Divide-perft
         else if(input.find("divide") != std::string::npos) {
             input.erase(0, 7);
-            m_board.Divide( stoi(input) );
+            board.Divide( stoi(input) );
         }
 
         else {
-            m_board.MakeMove(input);
+            board.MakeMove(input);
         }
 
     }

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -644,7 +644,7 @@ int Search::NegaMax(Board &board, int depth, int alpha, int beta) {
 // in tactical sequences (captures and checks).
 int Search::QuiescenceSearch(Board &board, int alpha, int beta) {
     assert(alpha >= -INFINITE_SCORE && beta <= INFINITE_SCORE && alpha < beta);
-    assert(m_ply < MAX_PLY);
+    assert(m_plyqs >= 0 && m_plyqs <= MAX_QS_PLIES);
 
     D( m_debug.Increment("Quiescence: _: Hits"); );
     D( if(m_plyqs <= 2 || m_plyqs % 5 == 0) m_debug.Increment("Quiescence: QPly " + std::to_string(m_plyqs)) );

--- a/src/Uci.cpp
+++ b/src/Uci.cpp
@@ -20,7 +20,7 @@ namespace {
     const std::string AUTHOR = "Carlos Sanchez Mayordomo";
     const std::string VERSION_MAJOR = "1";
     const std::string VERSION_MINOR = "1";
-    const std::string VERSION_PATCH = "0";
+    const std::string VERSION_PATCH = "2";
 }
 
 Uci::Uci() :

--- a/src/Uci.cpp
+++ b/src/Uci.cpp
@@ -1,6 +1,7 @@
 #include "Uci.h"
 
 #include "Board.h"
+#include "Engine.h"
 #include "Evaluation.h"
 #include "Hash.h"
 #include "NNUE.h"
@@ -23,17 +24,15 @@ namespace {
     const std::string VERSION_PATCH = "2";
 }
 
-Uci::Uci() :
-    m_tt(),
-    m_search(m_tt),
-    m_board()
-{}
+Uci::Uci() : m_engine(std::make_unique<Engine>()) {}
 
 Uci::~Uci() {
     StopAndJoin();
 }
 
 void Uci::Launch() {
+    Search& search = m_engine->search;
+    Board& board = m_engine->board;
 
     std::string line;
 
@@ -67,14 +66,12 @@ void Uci::Launch() {
         else if(token == "ucinewgame") {
             StopAndJoin();
 
-            m_tt.Clear();
-            m_search.ClearSearch(true);
-            m_board.Init();
+            m_engine->NewGame();
         }
         else if(token == "position") { Position(stream); }
         else if(token == "go") { Go(stream); }
         else if(token == "stop") { StopAndJoin(); }
-        else if(token == "ponderhit") { m_search.PonderHit(); }
+        else if(token == "ponderhit") { search.PonderHit(); }
         else if(token == "quit" || token == "q") {
             std::cout << "info string quitting" << std::endl;
             StopAndJoin();
@@ -88,12 +85,12 @@ void Uci::Launch() {
             Utils::Clock clock;
             clock.Start();
 
-            Board board;
-            board.Print();
+            Board perftBoard;
+            perftBoard.Print();
             if(token == "perft") {
-                std::cout << board.Perft(depth) << std::endl;
+                std::cout << perftBoard.Perft(depth) << std::endl;
             } else {
-                board.Divide(depth);
+                perftBoard.Divide(depth);
             }
 
             std::cout << "[" << token << " " << depth << "] " << clock.Elapsed() << " ms" << std::endl;
@@ -109,26 +106,26 @@ void Uci::Launch() {
             ShowHashMoves();
         }
         else if(token == "mirror") {
-            m_board.Mirror();
+            board.Mirror();
         }
         else if(token == "print") {
-            m_board.Print();
-            std::string activePlayer = (m_board.ActivePlayer() == WHITE) ? "WHITE" : "BLACK";
+            board.Print();
+            std::string activePlayer = (board.ActivePlayer() == WHITE) ? "WHITE" : "BLACK";
             P("Active player: " << activePlayer);
-            P("Ply: " << m_board.Ply());
-            P("Fifty-move rule: " << m_board.FiftyRule());
+            P("Ply: " << board.Ply());
+            P("Fifty-move rule: " << board.FiftyRule());
             std::string castlingRights;
-            if(m_board.CastlingRights() & 0b0001) castlingRights += "K"; else castlingRights += "-";
-            if(m_board.CastlingRights() & 0b0010) castlingRights += "Q"; else castlingRights += "-";
-            if(m_board.CastlingRights() & 0b0100) castlingRights += "k"; else castlingRights += "-";
-            if(m_board.CastlingRights() & 0b1000) castlingRights += "q"; else castlingRights += "-";
+            if(board.CastlingRights() & 0b0001) castlingRights += "K"; else castlingRights += "-";
+            if(board.CastlingRights() & 0b0010) castlingRights += "Q"; else castlingRights += "-";
+            if(board.CastlingRights() & 0b0100) castlingRights += "k"; else castlingRights += "-";
+            if(board.CastlingRights() & 0b1000) castlingRights += "q"; else castlingRights += "-";
             P("Castling rights: " << castlingRights);
-            Bitboard enpassant = m_board.EnPassantSquare();
+            Bitboard enpassant = board.EnPassantSquare();
             int epSquare = enpassant ? BitscanForward(enpassant) : -1;
             P("Enpassant square: " << epSquare);
-            P("ZKey: " << m_board.ZKey());
-            P("Static evaluation: " << Evaluation::Evaluate(m_board));
-            std::cout << "Move history: "; m_board.ShowHistory(); std::cout << std::endl;
+            P("ZKey: " << board.ZKey());
+            P("Static evaluation: " << Evaluation::Evaluate(board));
+            std::cout << "Move history: "; board.ShowHistory(); std::cout << std::endl;
         }
         else {
             std::cout << "Command not valid: " << line << std::endl;
@@ -138,6 +135,10 @@ void Uci::Launch() {
 
 void Uci::Bench(int depth, bool verbose) {
     StopAndJoin();
+
+    TT& tt = m_engine->tt;
+    Search& search = m_engine->search;
+    Board& board = m_engine->board;
 
     if(verbose)
         std::cout << "Running benchmark at depth " << depth << "..." << std::endl;
@@ -177,16 +178,16 @@ void Uci::Bench(int depth, bool verbose) {
         }
 
         // Set position
-        m_board.SetFen(testPositions[i]);
+        board.SetFen(testPositions[i]);
 
         // Set search limits
-        m_tt.Clear();
-        m_search.IterativeDeepening(m_board, UCI_Limits::FixDepth(depth), true);
+        tt.Clear();
+        search.IterativeDeepening(board, UCI_Limits::FixDepth(depth), true);
 
         // Get results using the engine's own calculations
-        u64 nodes = m_search.GetNodes();
-        i64 elapsed = m_search.GetLimits().ElapsedTime();
-        int nps = m_search.GetLimits().CalculateNPS(nodes);
+        u64 nodes = search.GetNodes();
+        i64 elapsed = search.GetLimits().ElapsedTime();
+        int nps = search.GetLimits().CalculateNPS(nodes);
 
         totalNodes += nodes;
         totalTime += elapsed;
@@ -197,8 +198,8 @@ void Uci::Bench(int depth, bool verbose) {
             std::cout << "  Nodes: " << nodes << std::endl;
             std::cout << "  Time: " << elapsed << " ms" << std::endl;
             std::cout << "  Speed: " << std::fixed << std::setprecision(2) << (nps / 1000.0) << " kN/s" << std::endl;
-            std::cout << "  Best move: " << m_search.BestMove().Notation() << std::endl;
-            std::cout << "  Score: " << m_search.BestScore() << std::endl;
+            std::cout << "  Best move: " << search.BestMove().Notation() << std::endl;
+            std::cout << "  Score: " << search.BestScore() << std::endl;
             std::cout << std::endl;
         }
     }
@@ -248,18 +249,20 @@ void Uci::Go(std::istringstream &stream) {
 
     }
 
-    m_searchThread = std::thread(&Uci::StartSearch, this, limits);
+    m_searchThread = std::thread(&Engine::StartSearch, m_engine.get(), limits);
 }
 
 void Uci::Position(std::istringstream &stream) {
     StopAndJoin();
+
+    Board& board = m_engine->board;
 
     std::string token;
 
     while(stream >> token) {
 
         if(token == "startpos") {
-            m_board.Init();
+            board.Init();
         }
 
         else if(token == "fen") {
@@ -267,22 +270,24 @@ void Uci::Position(std::istringstream &stream) {
             while(stream >> token && token != "moves") {
                 fen += token + " ";
             }
-            m_board.SetFen(fen);
+            board.SetFen(fen);
         }
 
         while(stream >> token) {
             if(token == "moves") continue;
             // P(token);
-            m_board.MakeMove(token);
+            board.MakeMove(token);
         }
 
-        // m_board.Print();
+        // board.Print();
     }
 
 }
 
 void Uci::SetOption(std::istringstream &stream) {
     StopAndJoin();
+
+    TT& tt = m_engine->tt;
 
     std::string token;
     stream >> token; //should be 'name'
@@ -297,7 +302,7 @@ void Uci::SetOption(std::istringstream &stream) {
             stream >> token;
             P(token);
 
-            m_tt.SetSize( stoi(token) );
+            tt.SetSize( stoi(token) );
         }
         else if(token == "Ponder") {
             stream >> token; //should be 'value'
@@ -312,7 +317,7 @@ void Uci::SetOption(std::istringstream &stream) {
                 UCI_PONDER = false;
         }
         else if(token == "ClearHash") {
-            m_tt.Clear();
+            tt.Clear();
         }
         else if(token == "Contempt") {
             stream >> token; // should be 'value'
@@ -349,9 +354,7 @@ void Uci::SetOption(std::istringstream &stream) {
 
             NNUE::Load(path);
 
-            m_tt.Clear();
-            m_search.ClearSearch(true);
-            m_board.Init();
+            m_engine->NewGame();
         }
         else if (token == "SyzygyPath") {
             stream >> token;
@@ -379,25 +382,23 @@ void Uci::SetOption(std::istringstream &stream) {
     }
 }
 
-void Uci::StartSearch(UCI_Limits limits) {
-    m_search.IterativeDeepening(m_board, limits);
-}
-
 void Uci::ShowHashMoves() {
-    MoveList moves = MoveGenerator::GenerateMoves(m_board);
+    TT& tt = m_engine->tt;
+    Board& board = m_engine->board;
+    MoveList moves = MoveGenerator::GenerateMoves(board);
 
     for(auto move : moves) {
-        m_board.MakeMove(move);
-        TTEntry* ttEntry = m_tt.Probe(m_board.ZKey());
+        board.MakeMove(move);
+        TTEntry* ttEntry = tt.Probe(board.ZKey());
         if(ttEntry) {
             P(move.Notation() << " " << static_cast<u8>(ttEntry->type) << "\t" << ttEntry->score);
         }
-        m_board.TakeMove(move);
+        board.TakeMove(move);
     }
 }
 
 void Uci::StopAndJoin() {
-    m_search.Stop();
+    m_engine->StopSearch();
 
     // Thread join
     if(m_searchThread.joinable()) {

--- a/src/Uci.cpp
+++ b/src/Uci.cpp
@@ -248,8 +248,7 @@ void Uci::Go(std::istringstream &stream) {
 
     }
 
-    m_limits = limits; // To avoid copies in std::thread that may cause memory misalignments
-    m_searchThread = std::thread(&Uci::StartSearch, this);
+    m_searchThread = std::thread(&Uci::StartSearch, this, limits);
 }
 
 void Uci::Position(std::istringstream &stream) {
@@ -380,8 +379,8 @@ void Uci::SetOption(std::istringstream &stream) {
     }
 }
 
-void Uci::StartSearch() {
-    m_search.IterativeDeepening(m_board, m_limits);
+void Uci::StartSearch(UCI_Limits limits) {
+    m_search.IterativeDeepening(m_board, limits);
 }
 
 void Uci::ShowHashMoves() {


### PR DESCRIPTION
Speed test:
build v1.1 windows (mingw-gcc): `3700 kN/s` --> build v1.1.2 windows (clang-cl): `4700 kN/s`

Bench: `3601894` (vs v1.1) ✔️ 
Bench: `3628774` (vs master) ✔️ 

No-regression vs v1.1
```
Elo   | 10.90 +- 15.08 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 1052 W: 357 L: 324 D: 371
Penta | [31, 113, 221, 114, 47]
```

No-regression vs master
```
Elo   | 3.02 +- 10.62 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [-15.00, 0.00]
Games | N: 2074 W: 655 L: 637 D: 782
Penta | [69, 236, 409, 254, 69]
```

## Release notes
Try to fix a crash appearing at CCRL tournaments.

- Fix: Windows build moved from `gcc` to `clang`.
  - `MinGW-gcc` sometimes generates aligned AVX instructions for unaligned memory, leading to crashes in some environments.
  - As a side effect, `clang-cl` build is **+20% NPS faster** on my test machine.
- Fix: update Fathom library, fixing C++20 compilation issues and memory misalignments.

The engine behavior and strength is exactly as v1.1 (aside from Windows binary speed increase).

**Diff**: https://github.com/casanche/casanchess/compare/v1.1...v1.1.2

https://github.com/casanche/casanchess/releases/tag/v1.1.2